### PR TITLE
PLAT-9301 Use a SVG instead of the TK-Font for the Info Round Icon

### DIFF
--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -2,6 +2,7 @@ import PropTypes, { Validator } from 'prop-types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Tooltip from '../tooltip';
+import InfoRoundIcon from './InfoRoundIcon';
 
 const IconTag = styled.i`
   cursor: pointer;
@@ -33,10 +34,12 @@ const Icon: React.FC<IconProps> = ({ iconName, tooltip }) => {
   return (
     <>
       <IconTag
-        className={`tk-ic-${iconName} tk-icon`}
+        className={`tk-ic-${iconName != 'info-round' ? iconName : ''} tk-icon`}
         onClick={handleClick}
         ref={setReferenceElement}
-      />
+      >
+        {iconName == 'info-round' ? <InfoRoundIcon /> : null}
+      </IconTag>
 
       {tooltip && (
         <Tooltip

--- a/src/components/icon/InfoRoundIcon.tsx
+++ b/src/components/icon/InfoRoundIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const SvgTag = styled.svg`
+  fill: currentColor;
+`;
+
+const InfoRoundIcon = () => {
+  return (
+    <SvgTag
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M8 12C8.55228 12 9 11.5523 9 11V8.5C9 7.94772 8.55228 7.5 8 7.5C7.44772 7.5 7 7.94772 7 8.5V11C7 11.5523 7.44772 12 8 12Z" />
+      <path d="M8 6.25C8.69036 6.25 9.25 5.69036 9.25 5C9.25 4.30964 8.69036 3.75 8 3.75C7.30964 3.75 6.75 4.30964 6.75 5C6.75 5.69036 7.30964 6.25 8 6.25Z" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58173 12.4183 0 8 0C3.58172 0 0 3.58173 0 8C0 12.4183 3.58172 16 8 16ZM8 14C11.3137 14 14 11.3137 14 8C14 4.68629 11.3137 2 8 2C4.68629 2 2 4.68629 2 8C2 11.3137 4.68629 14 8 14Z"
+      />
+    </SvgTag>
+  );
+};
+
+export default InfoRoundIcon;


### PR DESCRIPTION
**Fix bug** 

For the moment, TK-font's icons don't work on Windows, but they will work with the story [PLAT-9290](https://perzoinc.atlassian.net/browse/PLAT-9290).

In order not to block the integration of the input UI-Toolkit Element in the Symphony Element [PLAT-9199](https://perzoinc.atlassian.net/browse/PLAT-9199), it has been decided to **temporarily** use an SVG for the Info Round icon.

**Jira Ticket** : https://perzoinc.atlassian.net/browse/PLAT-9301

**Before fix:**

![beforeFix](https://user-images.githubusercontent.com/66668470/87910151-d3158080-ca69-11ea-8827-bc27f6a37831.png)

**After fix:** 
![WithFix](https://user-images.githubusercontent.com/66668470/87910275-0eb04a80-ca6a-11ea-8f28-00b8ee9d9e2c.png)
