### PR TITLE
PLAT-9472 Fix: ExpandableCard doesn't display the entire content

### DIFF
--- a/src/components/expandable-card/ExpandableCard.tsx
+++ b/src/components/expandable-card/ExpandableCard.tsx
@@ -32,7 +32,6 @@ const HeaderDiv = styled.div`
 `;
 
 const BodyDiv = styled.div`
-  max-height: 100vh;
   overflow: hidden;
   transition: max-height 300ms ease-in-out;
   &.collapsed {


### PR DESCRIPTION
**Jira Ticket**
https://perzoinc.atlassian.net/browse/PLAT-9472

**Fix**
Remove 100vh max-height of the ExpandableCard component

**Before fix:**
![BugExpandableCard](https://user-images.githubusercontent.com/66668470/91548115-31fdcd80-e925-11ea-99ac-a1593cbb6839.gif)


**After fix:**
![BugExpandableCard-OK](https://user-images.githubusercontent.com/66668470/91548290-78532c80-e925-11ea-8947-e2f44deadbae.gif)
