### PR TITLE
APP-3162 Implement List component

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-resize-detector": "^5.0.3",
     "react-transition-group": "^4.4.1",
     "shortid": "^2.2.15",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "react-virtualized": "^9.22.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -64,6 +65,7 @@
     "@types/react-dom": "^16.9.8",
     "@types/storybook__react": "^5.2.1",
     "@types/styled-components": "^5.1.0",
+    "@types/react-virtualized": "^9.21.10",
     "@typescript-eslint/eslint-plugin": "^3.0.0",
     "@typescript-eslint/parser": "^3.0.0",
     "babel-eslint": "^10.1.0",

--- a/spec/components/virtualized-list/VirtualizedList.spec.tsx
+++ b/spec/components/virtualized-list/VirtualizedList.spec.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import VirtualizedList from '../../../src/components/virtualized-list';
+
+describe('virtualized-list Component', () => {
+  it('renders without crash', () => {
+    const rowRenderer = () => (<div>Hello, World</div>)
+    const wrapper = shallow(<VirtualizedList height={200} rowHeight={40} rowCount={5} width={50} rowRenderer={rowRenderer}/>);
+    expect(wrapper.find('List').length).toBe(1);
+  })
+  it('forwards props to the virtualized-list element', () => {
+    const rowRenderer = () => (<div>Hello, World</div>)
+    const style = { background: 'gray' };
+    const wrapper = shallow(
+      <VirtualizedList height={200} rowHeight={40} rowCount={5} width={50} rowRenderer={rowRenderer} style={style}/>
+    );
+    expect(wrapper.find('List').prop('style')).toBe(style);
+  })
+})

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,7 +7,7 @@ import ExpandableCard from './expandable-card';
 import Tooltip from './tooltip';
 import Icon from './icon';
 import Validation from './validation';
-import Link from './link';
+import VirtualizedList from './virtualized-list';
 
 export {
   Button,
@@ -21,5 +21,5 @@ export {
   Tooltip,
   Validation,
   Icon,
-  Link,
+  VirtualizedList,
 };

--- a/src/components/virtualized-list/VirtualizedList.tsx
+++ b/src/components/virtualized-list/VirtualizedList.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { List, ListProps } from 'react-virtualized';
+
+const VirtualizedList: React.FC<ListProps> = ({
+  width,
+  height,
+  rowCount,
+  rowHeight,
+  rowRenderer,
+  ...rest
+}: ListProps) => {
+  return (
+    <List
+      rowCount={rowCount}
+      rowHeight={rowHeight}
+      width={width}
+      height={height}
+      rowRenderer={rowRenderer}
+      {...rest}
+    />
+  );
+}
+
+export default VirtualizedList;

--- a/src/components/virtualized-list/index.ts
+++ b/src/components/virtualized-list/index.ts
@@ -1,0 +1,3 @@
+import VirtualizedList from './VirtualizedList';
+
+export default VirtualizedList;

--- a/stories/VirtualizedList.stories.tsx
+++ b/stories/VirtualizedList.stories.tsx
@@ -1,0 +1,77 @@
+import *  as React from 'react';
+import VirtualizedList from '../src/components/virtualized-list';
+import Button from '../src/components/button';
+import Icon from '../src/components/icon';
+
+
+function createItems() {
+  const items = []
+  for (let i = 1; i < 20; i++) {
+    if(i % 2 === 0) {
+      items.push({name: 'Meeting ' + i, status: 'ongoing'})
+    } else {
+      items.push({name: 'Meeting ' + i, status: 'upcoming'})
+    }
+  }
+  return items;
+}
+
+
+function rowRenderer() {
+  return createItems().map((item, index) => {
+    return (
+      <div key={index}>
+        {/* text might not look good in dark mode, to be replaced by Typography component */}
+        {item.name} -
+        <Button iconButton variant="tertiary">
+          {item.status === 'ongoing' ? <Icon iconName={'call'}/> : <Icon iconName={'calendar'}/>}
+        </Button>
+      </div>
+    )
+  })
+}
+
+function noRowsRenderer() {
+  return (
+    <h3 style={{color: 'white', textAlign: 'center'}}>
+      This is an empty list.
+    </h3>
+  )
+}
+
+export const Lists: React.FC = () => (
+  <div style = {{display: 'flex'}}>
+    <div>
+      <h3>List with content</h3>
+      <p>List item is rendered by providing a rowRenderer</p><br/>
+      <VirtualizedList
+        rowCount={createItems().length}
+        rowHeight={50}
+        rowRenderer={rowRenderer}
+        width={200}
+        height={500}
+        noRowsRenderer={noRowsRenderer}
+        style={{background: 'lightgray'}}
+      />
+    </div>
+    <div style={{ marginLeft: '50px'}}>
+      <h3>Empty list</h3>
+      <p>Placeholder content can be rendered by providing a noRowsRenderer</p><br/>
+      <VirtualizedList
+        rowCount={0}
+        rowHeight={50}
+        rowRenderer={rowRenderer}
+        width={200}
+        height={500}
+        noRowsRenderer={noRowsRenderer}
+        style={{background: 'gray'}}
+      />
+    </div>
+  </div>
+);
+
+export default {
+  title: 'VirtualizedList',
+  component: Lists,
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,6 +2942,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-virtualized@^9.21.10":
+  version "9.21.10"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@types/react-virtualized/-/react-virtualized-9.21.10.tgz#cd072dc9c889291ace2c4c9de8e8c050da8738b7"
+  integrity sha1-zQctyciJKRrOLEyd6OjAUNqHOLc=
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.9.35":
   version "16.9.47"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@types/react/-/react-16.9.47.tgz#fb092936f0b56425f874d0ff1b08051fdf70c1ba"
@@ -4798,6 +4806,11 @@ clone-deep@^0.2.4:
     lazy-cache "^1.0.3"
     shallow-clone "^0.1.2"
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha1-mLMTT5q73yOyZjSRrOE8XAOnMYg=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -5520,7 +5533,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^5.0.1:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.0"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
   integrity sha1-V/0FTF+PNMUqPu/9t+fpPNNX2Vs=
@@ -10355,6 +10368,18 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.1:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-virtualized@^9.22.2:
+  version "9.22.2"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/react-virtualized/-/react-virtualized-9.22.2.tgz#217a870bad91e5438f46f01a009e1d8ce1060a5a"
+  integrity sha1-IXqHC62R5UOPRvAaAJ4djOEGClo=
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.13.1, react@^16.8.3, react@^16.9.17:
   version "16.13.1"


### PR DESCRIPTION
This is just a wrapper that wraps the List component from 'react-virtualized', which is the one currently being used to render chat list in SFE-Lite.  It receives a rowRender for rendering the list items.
<img width="798" alt="Screenshot 2020-10-23 at 10 27 52" src="https://user-images.githubusercontent.com/32852556/96975530-dc0b6780-151a-11eb-8f0a-92eab167579c.png">


________________________________________________________________
Another thought:  Do we really need a wrapper like this? Can we just use the library directly in open meetings?  Because what matters is the rowRenderer that renders the list item,  and we can use the UIToolkit components  when rendering the meeting item. 