### PR TITLE
PLAT-9605 - Move css import

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,10 +20,6 @@ module.exports = {
     },
   },
 
-  moduleNameMapper: {
-    '\\.(css|less)$': 'identity-obj-proxy',
-  },
-
   // A list of paths to modules that run some code to configure or set up
   // the testing framework before each test
   setupFilesAfterEnv: ['<rootDir>spec/init/setupTests.js'],

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^2.5.1",
-    "identity-obj-proxy": "^3.0.0",
     "jest": "^26.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -18,8 +18,6 @@ import DayPicker, {
   RangeModifier
 } from 'react-day-picker';
 
-import 'react-day-picker/lib/style.css';
-
 import TextField from '../input/TextField';
 import Icon from '../icon/Icon';
 

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,1 +1,2 @@
 import '@symphony/uitoolkit-styles/dist/css/uitoolkit.css';
+import 'react-day-picker/lib/style.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6975,11 +6975,6 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
-harmony-reflect@^1.4.6:
-  version "1.6.1"
-  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
-  integrity sha1-wQjU8rtFHv73o3hh/b2ucsm976k=
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -7226,13 +7221,6 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   integrity sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=
   dependencies:
     postcss "^7.0.14"
-
-identity-obj-proxy@^3.0.0:
-  version "3.0.0"
-  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
-  integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
-  dependencies:
-    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.4:
   version "1.1.13"


### PR DESCRIPTION
Cleaner import of scss, that allow us to remove the changes made of the config file

Prevent also the consumer projects that import "@symphony/uitoolkit-components" to have to configure css-loader