### PR TITLE
PLAT-9697 - Add name props to DatePicker

### DIFF
--- a/spec/components/date-picker/DatePicker.spec.tsx
+++ b/spec/components/date-picker/DatePicker.spec.tsx
@@ -31,6 +31,7 @@ describe('DatePicker Component', () => {
         previousMonth: 'Previous Month',
         nextMonth: 'Next Month',
       },
+      name: 'date-travel',
       placeholder: 'MM-DD-YYYY',
       locale: 'en-US',
       placement: 'bottom',
@@ -56,6 +57,7 @@ describe('DatePicker Component', () => {
     expect(wrapperField.prop('label')).toBe(props.label);
     expect(wrapperField.prop('placeholder')).toBe(props.placeholder);
     expect(wrapperField.prop('tooltip')).toBe(props.tooltip);
+    expect(wrapperField.prop('name')).toBe(props.name);
   });
   it('should properly pass props to React Day Picker', () => {
     const props = createTestProps({});

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -66,6 +66,7 @@ type DatePickerComponentProps = {
     previousMonth: string;
     nextMonth: string;
   };
+  name?: string;
   placeholder?: string;
   locale?: string;
   placement?: 'top' | 'bottom' | 'right' | 'left';
@@ -90,6 +91,7 @@ const DatePicker: FunctionComponent<DatePickerComponentProps> = ({
     previousMonth: 'Previous Month',
     nextMonth: 'Next Month',
   },
+  name,
   placeholder,
   locale = 'en-US',
   placement = 'bottom',
@@ -248,6 +250,7 @@ const DatePicker: FunctionComponent<DatePickerComponentProps> = ({
   const textfieldProps = {
     disabled,
     label,
+    name,
     placeholder: placeholder || format.toUpperCase(),
     tooltip,
   };
@@ -353,6 +356,7 @@ DatePicker.propTypes = {
     nextMonth: PropTypes.string,
   }),
   locale: PropTypes.string,
+  name: PropTypes.string,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/PLAT-9697

`name` attribute is used in Elements

We need to make DatePicker accept this attribute to pass it to the <input tag

`name` attribute is especially used in Content Export