### PR TITLE
PLAT-9697 - Fix shifting date according to starting days (Sunday, or …

### DIFF
--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -26,6 +26,7 @@ import {
   getMonths,
   getWeekdaysLong,
   getWeekdaysShort,
+  getFirstDayOfWeek
 } from './utils/dateUtils';
 
 import { matchDay } from './utils/matchDayUtils';
@@ -341,6 +342,7 @@ const DatePicker: FunctionComponent<DatePickerComponentProps> = ({
             months={getMonths(now, getLocale)}
             weekdaysLong={getWeekdaysLong(now, getLocale)}
             weekdaysShort={getWeekdaysShort(now, getLocale)}
+            firstDayOfWeek={getFirstDayOfWeek(now, getLocale)}
             fixedWeeks
           ></DayPicker>
         </DatePickerContainer>

--- a/src/components/date-picker/utils/dateUtils.tsx
+++ b/src/components/date-picker/utils/dateUtils.tsx
@@ -36,10 +36,16 @@ export function getWeekdaysShort(date: Date, locale: Locale): string[] {
   return getWeekdays(date, locale, 'eeeeee');
 }
 
+/**
+ * Return a list of translated weekdays, always starting by Sunday
+ * @param date 
+ * @param locale 
+ * @param pattern 
+ */
 function getWeekdays(date: Date, locale: Locale, pattern: string): string[] {
   const arr = eachDayOfInterval({
-    start: startOfWeek(date, { locale }),
-    end: endOfWeek(date, { locale }),
+    start: startOfWeek(date), // not providing locale param because react-day-picker expect a list starting by Sunday
+    end: endOfWeek(date), // not providing locale param because react-day-picker expect a list starting by Sunday
   });
 
   return arr.map((item) => {

--- a/stories/DatePicker.stories.tsx
+++ b/stories/DatePicker.stories.tsx
@@ -73,6 +73,7 @@ export const MoreExamples: React.SFC = () => {
         <DatePicker
           format="yyyy年MM月dd日"
           locale="ja"
+          todayButton="今日"
         />
       </div>
       <hr />


### PR DESCRIPTION
…Monday)
## Description
When the locale doesn't start the week by Sunday, the calendar is only shifting the weekdays name, and not the cells number

## Current
![image](https://user-images.githubusercontent.com/56824367/97422265-de503600-190d-11eb-9304-ce94ebc99663.png)

## Expected
![image](https://user-images.githubusercontent.com/56824367/97422436-15bee280-190e-11eb-9b0b-7cd2f541e758.png)
