### PR TITLE
PLAT-9685 - Let TextField generate tk-input__icon automatically

### DIFF
--- a/spec/components/input/TextComponent.spec.tsx
+++ b/spec/components/input/TextComponent.spec.tsx
@@ -71,7 +71,7 @@ describe('TextComponent Component', () => {
     });
     describe('should handle icon props', () => {
       const iconProps = {
-        className: 'tk-input__icon my-custom-class',
+        className: 'my-custom-class',
         iconName: 'calendar',
         tabIndex: 0,
         onClick: jest.fn(),
@@ -90,6 +90,7 @@ describe('TextComponent Component', () => {
         const wrapperIcon = wrapper.find('Icon');
         expect(wrapperIcon.length).toBe(1);
         expect(wrapperIcon.prop('iconName')).toBe(iconProps.iconName);
+        expect(wrapperIcon.prop('className')).toContain('tk-input__icon');
         expect(wrapperIcon.prop('className')).toContain(iconProps.className);
         expect(wrapperIcon.prop('tabIndex')).toBe(iconProps.tabIndex);
         expect(wrapperIcon.prop('onClick')).toBe(iconProps.onClick);

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -267,7 +267,7 @@ const DatePicker: FunctionComponent<DatePickerComponentProps> = ({
           })}
           iconElement={
             <Icon
-              className={classNames('tk-input__icon', {
+              className={classNames({
                 active: showPicker,
               })}
               disabled={disabled}

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -79,7 +79,8 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
   onClick,
   onFocus,
   onKeyDown,
-  ...rest }) => {
+  ...rest
+}) => {
   const [showTooltip, setShowTooltip] = useState(false);
   const [hideText, setHideText] = useState(masked || false);
 
@@ -164,7 +165,15 @@ const TextComponent: React.FC<TextComponentPropsWithType> = ({
           disabled={disabled}
           {...rest}
         />
-        {iconElement && type == Types.TEXTFIELD ? iconElement : null}
+        {iconElement && type == Types.TEXTFIELD
+        // Clone the iconElement in order to attach className 'tk-input__icon' 
+          ? React.cloneElement(iconElement, {
+            className: classNames(
+              'tk-input__icon',
+              iconElement.props.className
+            ),
+          })
+          : null}
         {type == Types.TEXTFIELD ? (
           <button
             className="tk-input__hide"

--- a/stories/TextField.stories.tsx
+++ b/stories/TextField.stories.tsx
@@ -57,7 +57,7 @@ export const TextFields: React.SFC = () => {
         </p>
         <TextField
           iconElement={
-            <Icon iconName={'calendar'} className="tk-input__icon" />
+            <Icon iconName={'calendar'}  />
           }
         ></TextField>
       </div>
@@ -70,7 +70,6 @@ export const TextFields: React.SFC = () => {
         <TextField
           iconElement={
             <Icon
-              className="tk-input__icon"
               iconName={'calendar'}
               tabIndex={0}
               onClick={() => logChange('clicked')}


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/PLAT-9685

The user should not have to put it manually

To attach a props to a "child" props, we need to use React.cloneElement