### PR TITLE
APP-3264 | allow other props to be passed to Modal component

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -42,7 +42,7 @@ export const Modal: React.FC<ModalProps> = ({
   )
 
   return (
-    <div className={containerClasses} onClick={onClose} {...rest}>
+    <div {...rest} className={containerClasses} onClick={onClose}>
       <div className={sizeClasses}>
         {closeButton &&  <button className={buildClass('close')} onClick={onClose}/>}
         {children}


### PR DESCRIPTION
## Description

This PR adds a `rest` parameter, that passes on other props, such as test-IDs, to the rendered Modal component.

[JIRA-ticket](https://perzoinc.atlassian.net/browse/APP-3264)