### PR TITLE
PLAT-9931 PLAT-9937 - Date Picker - Improve before / after assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@symphony/uitoolkit-styles": "1.2.0-SNAPSHOT.1",
+    "@symphony/uitoolkit-styles": "1.2.0",
     "@types/classnames": "^2.2.10",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",

--- a/spec/components/date-picker/DatePicker.spec.tsx
+++ b/spec/components/date-picker/DatePicker.spec.tsx
@@ -143,7 +143,7 @@ describe('DatePicker Component', () => {
   });
 
   describe('should open overlay', () => {
-    test.each([[Keys.ENTER], [Keys.SPACE], [Keys.SPACEBAR]])('on %p on TextField', async (key) => {
+    test.each([[Keys.ENTER]])('on %p on TextField', async (key) => {
       const wrapper = mount(<DatePicker />);
       expect(wrapper.state('showPicker')).toBe(false);
       await act(async () => {
@@ -168,7 +168,7 @@ describe('DatePicker Component', () => {
       expect(wrapper.state('showPicker')).toBe(true);
       wrapper.unmount();
     });
-    test.each([[Keys.ENTER], [Keys.SPACE], [Keys.SPACEBAR]])('on %p on TextField', async (key) => {
+    test.each([[Keys.ENTER], [Keys.SPACE], [Keys.SPACEBAR]])('on %p on Icon', async (key) => {
       const wrapper = mount(<DatePicker />);
       expect(wrapper.state('showPicker')).toBe(false);
       await act(async () => {

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -359,8 +359,6 @@ class DatePicker extends Component<
   private handleKeyDownInput(e: React.KeyboardEvent): void {
     const { showPicker } = this.state;
     switch (e.key) {
-    case Keys.SPACE:
-    case Keys.SPACEBAR:
     case Keys.ENTER:
       cancelEvent(e);
       this.setState({ showPicker: !showPicker });

--- a/src/components/date-picker/utils/matchDayUtils.tsx
+++ b/src/components/date-picker/utils/matchDayUtils.tsx
@@ -1,13 +1,13 @@
 import { Modifier } from '../model/Modifiers';
 
-import { isSameDay, differenceInDays, isWithinInterval } from 'date-fns';
+import { differenceInDays, isSameDay, isAfter, isBefore, isWithinInterval } from 'date-fns';
 
 function isDayAfter(day1: Date, day2: Date): boolean {
-  return differenceInDays(day1, day2) > 0;
+  return isAfter(day1, day2) && !isSameDay(day1, day2);
 }
 
 function isDayBefore(day1: Date, day2: Date): boolean {
-  return differenceInDays(day1, day2) < 0;
+  return isBefore(day1, day2) && !isSameDay(day1, day2);
 }
 
 function matchDate(day: Date, matcher: Modifier): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,10 +2361,10 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@symphony/uitoolkit-styles@1.2.0-SNAPSHOT.1":
-  version "1.2.0-SNAPSHOT.1"
-  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/uitoolkit-styles/-/@symphony/uitoolkit-styles-1.2.0-SNAPSHOT.1.tgz#b582e9c87ef5a1c73d49967acc52159c79e9b8ec"
-  integrity sha1-tYLpyH71occ9SZZ6zFIVnHnpuOw=
+"@symphony/uitoolkit-styles@1.2.0":
+  version "1.2.0"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/uitoolkit-styles/-/@symphony/uitoolkit-styles-1.2.0.tgz#ae41de9d5545b87c383b8a4c7c1c1b7d909c4312"
+  integrity sha1-rkHenVVFuHw4O4pMfBwbfZCcQxI=
 
 "@types/anymatch@*":
   version "1.3.1"


### PR DESCRIPTION
## Ticket
https://perzoinc.atlassian.net/browse/PLAT-9931
https://perzoinc.atlassian.net/browse/PLAT-9937

This improvement will help fixing this issue
![image](https://user-images.githubusercontent.com/56824367/100726791-b26d1800-33c5-11eb-94c9-5eae3664ff72.png)


**Also** remove "SPACE" interaction on TextField, we want only ENTER to open the calendar

## Description
differenceInDays has an edge case as counts only full days. 
Edge case:
 If 2020-12-09 at 13:19pm is compared with 2020-10-10 at 00:00am, it returns **0** (but we want 1 as it is not the same day)

So we changed also the assertion to **"isBefore and not isSameDay"**

