### PR TITLE
APP-4066 Fix mistmatch between ID and 'for' referenced by the Label

### DIFF
--- a/spec/components/label-tooltip-decorator/LabelTooltipDecorator.spec.tsx
+++ b/spec/components/label-tooltip-decorator/LabelTooltipDecorator.spec.tsx
@@ -17,9 +17,9 @@ describe('LabelTooltipDecorator Component', () => {
     });
     it('should display a label if provided', () => {
       const id = 'textfield-1234567890';
-      let wrapper = shallow(<LabelTooltipDecorator />);
+      let wrapper = shallow(<LabelTooltipDecorator/>);
       expect(wrapper.find('label.tk-label').length).toBe(0);
-      wrapper = shallow(<LabelTooltipDecorator label="LABEL" id={id} />);
+      wrapper = shallow(<LabelTooltipDecorator label="LABEL" htmlFor={id} />);
       expect(wrapper.find('label.tk-label').text()).toEqual('LABEL');
       expect(wrapper.find(`label[htmlFor="${id}"]`)).toHaveLength(1);
     });

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -263,7 +263,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
     return (
       <div>
         <LabelTooltipDecorator
-          id={id}
+          htmlFor={id}
           label={label}
           placement={'top'}
           tooltip={tooltip}

--- a/src/components/input/TextComponent.tsx
+++ b/src/components/input/TextComponent.tsx
@@ -114,9 +114,11 @@ const TextComponent: React.FC<
     }, []);
 
     // Generate unique ID if not provided
-    const ariaId = useMemo(() => {
-      return id || `hint-${shortid.generate()}`;
+    const inputId = useMemo(() => {
+      return id || `tk-input-${shortid.generate()}`;
     }, [id]);
+
+    const tooltipId = useMemo(()=> (`tk-hint-${shortid.generate()}`),[]);
 
     const handleViewText = (event) => {
       if (disabled) return;
@@ -139,7 +141,8 @@ const TextComponent: React.FC<
         })}
       >
         <LabelTooltipDecorator
-          id={ariaId}
+          id={tooltipId}
+          htmlFor={inputId}
           label={label}
           placement={'top'}
           tooltip={tooltip}
@@ -152,10 +155,10 @@ const TextComponent: React.FC<
           })}
         >
           <TagName
-            id={id}
+            id={inputId}
             ref={ref}
             aria-autocomplete="none"
-            aria-describedby={tooltip && ariaId}
+            aria-describedby={tooltip && tooltipId}
             aria-label={label}
             aria-placeholder={placeholder}
             aria-readonly={disabled}

--- a/src/components/label-tooltip-decorator/LabelTooltipDecorator.tsx
+++ b/src/components/label-tooltip-decorator/LabelTooltipDecorator.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 
 type LabelTooltipDecoratorProps = {
   id?: string;
+  htmlFor?: string;
   label?: string;
   placement?: 'top' | 'bottom' | 'right' | 'left';
   tooltip?: string;
@@ -27,6 +28,7 @@ const LabelTooltipDecoratorTooltip = styled.div`
 `;
 const LabelTooltipDecoratorPropTypes = {
   id: PropTypes.string,
+  htmlFor: PropTypes.string,
   label: PropTypes.string,
   tooltip: PropTypes.string,
   tooltipCloseLabel: PropTypes.string,
@@ -34,6 +36,7 @@ const LabelTooltipDecoratorPropTypes = {
 
 const LabelTooltipDecorator: React.FC<LabelTooltipDecoratorProps> = ({
   id,
+  htmlFor,
   label,
   placement,
   tooltip,
@@ -50,7 +53,7 @@ const LabelTooltipDecorator: React.FC<LabelTooltipDecoratorProps> = ({
   return label || tooltip ? (
     <LabelTooltipDecoratorHeader className="tk-input-group__header">
       {label ? (
-        <label className={classes} htmlFor={id}>
+        <label className={classes} htmlFor={htmlFor}>
           {label}
         </label>
       ) : null}


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4066

**Fix:**
Fix mistmatch between ID and 'for' referenced by the Label

On label tag:
- 'for' should reference the input
- a click on the label should set the focus on the input

On input tag, the prop 'aria-describedby' should reference the ID of the tooltip

![Screenshot 2021-05-11 at 15 21 22](https://user-images.githubusercontent.com/66668470/117822155-91f69300-b26c-11eb-8deb-53362631def4.png)
