### PR TITLE
feat(error): Use the icon from .tk-validation__errors

### DIFF
--- a/packages/components/src/components/validation/Validation.tsx
+++ b/packages/components/src/components/validation/Validation.tsx
@@ -230,7 +230,7 @@ class Validation extends React.Component<
         {hasErrors ? (
           <ul className="tk-validation__errors">
             {this.state.errors.map((error, index) => (
-              <li key={index} aria-errormessage={error}><Icon iconName="alert-triangle"/>{error}</li>
+              <li key={index} aria-errormessage={error}>{error}</li>
             ))}
           </ul>
         ) : null}


### PR DESCRIPTION
## Description

- Use the generated icon from .tk-validation__errors

## Demo

![image](https://user-images.githubusercontent.com/56824367/149371544-bd3c924a-f49f-4603-83c0-0254d4ca48db.png)
![image](https://user-images.githubusercontent.com/56824367/149371501-2d6c2c69-ccbd-427f-9dd8-e55fadb86498.png)
