### PR TITLE
APP-4857 - Enforcing box-sizing to tk-dropdown-menu__item

### DIFF
--- a/packages/styles/src/components/atoms/_dropdown-menu.scss
+++ b/packages/styles/src/components/atoms/_dropdown-menu.scss
@@ -12,8 +12,9 @@ $list-font-size-icon: toRem(16);
   }
 
   &__item {
+    box-sizing: border-box;
     font-size: toRem(14);
-    height: toRem(20);
+    height: toRem(32);
     line-height: toRem(20);
     padding: toRem(6) toRem(0) toRem(6) toRem(16);
   }


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/APP-4857

Storybook and SFE-Lite have different box-sizing causing a discrepancy how `tk-dropdown-menu__item` gets rendered because it has a height property.

I think 1) Storybook should use border-box as well to reflect the SFE-Lite environment and 2) All components should have a box-sizing enforced so there are no implicit dependencies causing a different rendering. Future discussion and PRs.