### PR TITLE
Fix: Doc code preview "No display name"

### DIFF
--- a/packages/components/stories/TimePicker.stories.tsx
+++ b/packages/components/stories/TimePicker.stories.tsx
@@ -211,7 +211,7 @@ export default {
   decorators: [
     (Story) => (
       <div className="flex-col" style={{ width: '100%', height: '350px' }}>
-        <Story />
+        {Story()}
       </div>
     ),
   ],

--- a/packages/components/stories/Tooltip.stories.tsx
+++ b/packages/components/stories/Tooltip.stories.tsx
@@ -10,7 +10,7 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ margin: '150px auto', textAlign: 'center' }}>
-        <Story />
+        {Story()}
       </div>
     ),
   ],
@@ -39,7 +39,7 @@ const Template = (args) => {
 const addExplanation = (explanation) => (Story) => (
   <div>
     <p>{explanation}</p>
-    <Story />
+    {Story()}
   </div>
 );
 export const Standard = Template.bind({});


### PR DESCRIPTION
## Description

Fix code preview displays "No display name" by applying the fix described [here](https://github.com/storybookjs/storybook/issues/12596#issuecomment-947940406)

## Demo

**Before**
<img width="1411" alt="Screenshot 2022-01-25 at 09 31 41" src="https://user-images.githubusercontent.com/66668470/150940456-c09167ba-2704-4709-a1dd-7323760fddaa.png">


**After**
<img width="1300" alt="Screenshot 2022-01-25 at 09 31 02" src="https://user-images.githubusercontent.com/66668470/150940491-459efeef-bfcb-422c-a3db-3b6a43aa54ed.png">

