### PR TITLE
Fix: Remove "undefined" variant in the Loader component

### DIFF
--- a/packages/components/src/components/loader/Loader.tsx
+++ b/packages/components/src/components/loader/Loader.tsx
@@ -21,8 +21,7 @@ const Loader: React.FC<LoaderProps> = ({
   const classes = classNames(
     className,
     `${prefix}-${type}`,
-    `${prefix}--${variant}`,
-    
+    {[`${prefix}--${variant}`]: variant},
   );
   return (
     <i


### PR DESCRIPTION
## Description

Fix: 'undefined' variant is added in the Loader component when no variant is defined.

## Demo

Before
<img width="525" alt="Screenshot 2022-01-25 at 10 45 50" src="https://user-images.githubusercontent.com/66668470/150952706-a8450484-b90a-403a-af3f-886a4b259dbb.png">


After
<img width="414" alt="Screenshot 2022-01-25 at 10 23 47" src="https://user-images.githubusercontent.com/66668470/150952681-67645486-4420-486b-986a-65f3b92e83b7.png">

