### PR TITLE
APP-4919: Fix displayed option label in Dropdown (multi select)

### DIFF
--- a/packages/components/spec/components/dropdown/Dropdown.spec.tsx
+++ b/packages/components/spec/components/dropdown/Dropdown.spec.tsx
@@ -108,6 +108,39 @@ describe('Dropdown component test suite =>', () => {
         expect(onClear).toBeCalled();
         expect(getByText('Select...')).toBeTruthy();
       });
+
+
+      it('should support custom option structure', async () => {
+        const customOptions = [
+          { firstName: 'Eve', lastName: 'Hill' },
+          { firstName: 'Justin', lastName: 'Case' },
+          { firstName: 'Anna', lastName: 'Conda' },
+        ]
+        const bindLabel = (option) => option.lastName;
+
+        const { getByText, queryByText } = render(
+          <Dropdown
+            isMultiSelect
+            options={customOptions}
+            onChange={onChange}
+            onClear={onClear}
+            bindLabel={bindLabel}
+          />
+        );
+
+        const input = screen.getByRole('textbox');
+        userEvent.click(input);
+
+        expect(getByText('Hill')).toBeInTheDocument();
+        expect(getByText('Case')).toBeInTheDocument();
+        expect(getByText('Conda')).toBeInTheDocument();
+
+
+        userEvent.click(getByText('Case'));
+        expect(getByText('Case')).toBeInTheDocument();
+        expect(queryByText('Hill')).not.toBeInTheDocument();
+        expect(queryByText('Conda')).not.toBeInTheDocument();
+      });
     });
 
     describe('when is Multiselect', () => {
@@ -539,8 +572,8 @@ describe('Dropdown component test suite =>', () => {
         { label: 'Option 2', value: '1' },
         { label: 'Option 3 ', value: '1' },
       ];
-      
-      render(<Dropdown options={options}/>);
+
+      render(<Dropdown options={options} />);
       const input = screen.getByRole('textbox');
       userEvent.click(input);
       userEvent.click(screen.getByText('Option 1'));
@@ -549,6 +582,6 @@ describe('Dropdown component test suite =>', () => {
       expect(screen.getAllByText('Option 1')[1].classList.contains('tk-select__option--is-selected')).toBeTruthy();
       expect(screen.getByText('Option 2').classList.contains('tk-select__option--is-selected')).toBeFalsy();
       expect(screen.getByText('Option 3').classList.contains('tk-select__option--is-selected')).toBeFalsy();
-    }); 
+    });
   });
 });

--- a/packages/components/src/components/dropdown/CustomRender.tsx
+++ b/packages/components/src/components/dropdown/CustomRender.tsx
@@ -35,21 +35,21 @@ export const DefaultOptionRenderer = (props: any) => {
     data: props.data,
     inputValue: props.selectProps?.inputValue,
   };
-  
+
   return isSearchHeaderOption && enableTermSearch ? (
-    inputValue && 
-      <components.Option {...props}>
-        <HeaderComp {...props} />
-      </components.Option>
+    inputValue &&
+    <components.Option {...props}>
+      <HeaderComp {...props} />
+    </components.Option>
   ) : <>
-    {OptionRenderer ? 
+    {OptionRenderer ?
       <div className="tk-option" role="option">
         <components.Option {...props}>
           <OptionRenderer {...rendererProps} />
         </components.Option>
       </div>
       : <div className="tk-option" role="option">
-        <components.Option {...props} className={classNames(classNamePrefix && mode ? `${classNamePrefix}__option--${mode}` : null)}/>
+        <components.Option {...props} className={classNames(classNamePrefix && mode ? `${classNamePrefix}__option--${mode}` : null)} />
       </div>
     }
   </>;
@@ -65,7 +65,7 @@ export const Input = (props: any) => {
     onCopy={props?.selectProps?.onCopy}
     onCut={props?.selectProps?.onCut}
     onDrag={props?.selectProps?.onDrag}
-    onKeyUp={props?.selectProps?.onKeyUp}  
+    onKeyUp={props?.selectProps?.onKeyUp}
     isHidden={inputAlwaysDisplayed ? !inputAlwaysDisplayed : false}
   />;
 }
@@ -76,7 +76,7 @@ export const SingleValue = ({ children, data, selectProps, ...props }: any) => {
   const isSearchHeaderSelected = rendererProps.data.searchHeader;
   return (
     <components.SingleValue {...props}>
-      { isSearchHeaderSelected ?  <div>{inputValue}</div> :  (InputRenderer ? <InputRenderer {...rendererProps} /> : children )}
+      {isSearchHeaderSelected ? <div>{inputValue}</div> : (InputRenderer ? <InputRenderer {...rendererProps} /> : children)}
     </components.SingleValue>);
 };
 
@@ -91,16 +91,16 @@ export const DefaultTagRenderer = (props: any) => {
       : <components.MultiValue {...props}>
         <div onMouseDown={stopPropagation} className="tk-tag__container">
           <div className="tk-tag">
-            {props.data?.label}
+            {props.selectProps.getOptionLabel(props.data)}
           </div>
-          <Icon className="tk-tag__close-icon" iconName="cross-round" onClick={props.removeProps.onClick} tabIndex={0}/>
+          <Icon className="tk-tag__close-icon" iconName="cross-round" onClick={props.removeProps.onClick} tabIndex={0} />
         </div>
       </components.MultiValue>}
   </>
   );
 };
 
-export const MultiValueContainerOverride = ({ children, ...props }: any) => 
+export const MultiValueContainerOverride = ({ children, ...props }: any) =>
   <components.MultiValueContainer {...props}>
     <div>{children}</div>
   </components.MultiValueContainer>;
@@ -115,34 +115,34 @@ export const DropdownIndicator = (props: any) => {
   const { isMulti, displayArrowIndicator, menuIsOpen } = props?.selectProps;
 
   return !displayArrowIndicator ?
-    null : 
+    null :
     <components.DropdownIndicator
       {...props}
       innerProps={{ 'data-testid': props.selectProps['data-testid'] }}
     >
       {!isMulti && <Icon
         className="tk-select__single-value"
-        iconName={ menuIsOpen ? 'drop-up' : 'drop-down' }
+        iconName={menuIsOpen ? 'drop-up' : 'drop-down'}
       />}
     </components.DropdownIndicator>;
 };
 
-export const ClearIndicator = (props: any) => 
+export const ClearIndicator = (props: any) =>
   <components.ClearIndicator {...props}>
-    <Icon  className="tk-select__close-icon" iconName="cross-round" onKeyPress={props.clearValue} tabIndex={0} />
+    <Icon className="tk-select__close-icon" iconName="cross-round" onKeyPress={props.clearValue} tabIndex={0} />
   </components.ClearIndicator>;
 
 export const Control = ({ children, selectProps, ...props }: any) => {
-  const {iconName} = selectProps;
+  const { iconName } = selectProps;
   return (<div>
     <components.Control {...props} className="tk-select__container">
-      {iconName && <Icon iconName={iconName} className="tk-input__icon"/>}
+      {iconName && <Icon iconName={iconName} className="tk-input__icon" />}
       {children}
     </components.Control>
   </div>);
 };
 
-export const NoOptionsMessage = ({selectProps, ...props}: any) =>
+export const NoOptionsMessage = ({ selectProps, ...props }: any) =>
   <components.NoOptionsMessage {...props}>
     <div>{selectProps?.noOptionMessage}</div>
   </components.NoOptionsMessage>;
@@ -150,25 +150,25 @@ export const NoOptionsMessage = ({selectProps, ...props}: any) =>
 const HeaderComp = (props: any) => {
   const { termSearchMessage, inputValue } = props.selectProps;
   return (<div>
-    <Icon iconName="right-arrow" className="tk-mr-1h"/>
+    <Icon iconName="right-arrow" className="tk-mr-1h" />
     <span>
       {termSearchMessage && typeof termSearchMessage === 'string'
         ? termSearchMessage : termSearchMessage ? termSearchMessage(inputValue) : 'Search for term '}
-        &apos;{inputValue}&apos;
+      &apos;{inputValue}&apos;
     </span>
   </div>);
 };
 
 /* Override default loading styles to the react-select */
-export const LoadingMessage = () => <div className="tk-select-loading"><Loader/></div>;
+export const LoadingMessage = () => <div className="tk-select-loading"><Loader /></div>;
 
 /* This component is used when the enableTermSearch prop
  * is activated to handle the header Option selection */
-export const DropdownList = ({selectProps, ...props}: any) => {
+export const DropdownList = ({ selectProps, ...props }: any) => {
   if (selectProps?.enableTermSearch) {
     const select = selectProps?.selectRef?.current?.select;
-    const  selectValueSync  = select?.state?.selectValue;
-    const  selectValueAsync  = select?.state?.value?.searchHeader;
+    const selectValueSync = select?.state?.selectValue;
+    const selectValueAsync = select?.state?.value?.searchHeader;
     const { searchHeaderOption } = selectProps?.parentInstance;
     const { inputValue } = selectProps;
     // Focus on first option and differenciate between Group Options and simple options
@@ -178,8 +178,8 @@ export const DropdownList = ({selectProps, ...props}: any) => {
     }
     focusThis = focusThis || searchHeaderOption;
     // Clear the value if header option is selected
-    if (selectValueSync && selectValueSync[0]?.searchHeader ) {
-        select?.clearValue();
+    if (selectValueSync && selectValueSync[0]?.searchHeader) {
+      select?.clearValue();
     }
     if (selectValueAsync) {
       select?.select?.clearValue();
@@ -195,13 +195,13 @@ export const DropdownList = ({selectProps, ...props}: any) => {
     }, [inputValue]);
     // Skip focusing on the headerOption if the inputValue is empty
     React.useEffect(() => {
-      if(select?.state?.focusedOption?.value === '') {
+      if (select?.state?.focusedOption?.value === '') {
         select?.setState({ focusedOption: focusThis });
       }
     }, [select?.state?.focusedOption]);
   }
   return <components.MenuList
-    className={ 'tk-mt-1 tk-mb-1' }
+    className={'tk-mt-1 tk-mb-1'}
     {...props}
   >
     {props.children}

--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -182,6 +182,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
       tooltipCloseLabel,
       value,
       variant,
+      bindLabel,
       ...otherProps
     } = this.props;
 
@@ -194,7 +195,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
             valueContainer: (base: CSSProperties) => ({
               ...base, maxHeight: `${maxHeight}px`
             }),
-            input: (base: CSSProperties) => ({...base, margin: (size === 'small') ? '0 2px' : undefined, color: 'inherit'}),
+            input: (base: CSSProperties) => ({ ...base, margin: (size === 'small') ? '0 2px' : undefined, color: 'inherit' }),
             multiValue: (base: CSSProperties) => ({ ...base, margin: '0' })
           }}
           parentInstance={this}
@@ -222,7 +223,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           defaultValue={defaultValue}
           id={id}
           name={name}
-          className={classNames(prefix, {[`${prefix}--${variant}`]: variant}, {[`${prefix}--${size}`]: size})}
+          className={classNames(prefix, { [`${prefix}--${variant}`]: variant }, { [`${prefix}--${size}`]: size })}
           closeMenuOnSelect={closeMenuOnSelect}
           classNamePrefix={prefix}
           value={value}
@@ -261,6 +262,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           enableTermSearch={enableTermSearch}
           termSearchMessage={termSearchMessage}
           getOptionValue={this.bindValue}
+          getOptionLabel={bindLabel}
           blurInputOnSelect={blurInputOnSelect}
           menuPortalTarget={menuPortalTarget}
           menuShouldBlockScroll={menuShouldBlockScroll}
@@ -274,7 +276,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           tooltipCloseLabel={tooltipCloseLabel}
           showRequired={showRequired}
         />
-        {helperText &&  <div className="tk-input__helper">{helperText}</div>}
+        {helperText && <div className="tk-input__helper">{helperText}</div>}
       </div>
     );
   }
@@ -290,7 +292,8 @@ export class Dropdown<T = LabelValue> extends React.Component<
     menuPortalStyles: {},
     menuShouldBlockScroll: false,
     menuShouldScrollIntoView: true,
-    size: 'medium'
+    size: 'medium',
+    bindLabel: (option) => option.label,
   };
 }
 

--- a/packages/components/src/components/dropdown/interfaces.ts
+++ b/packages/components/src/components/dropdown/interfaces.ts
@@ -88,6 +88,8 @@ export type DropdownProps<T> = {
   autoScrollToCurrent?: boolean;
   /** Path in custom object to the unique identifier of the option */
   bindValue?: string;
+  /** Path in custom object to the label of the option */
+  bindLabel?: (option: any) => string;
   /** Blur the field when an item is selected */
   blurInputOnSelect?: boolean;
   /** Optional CSS class name for the dropdown container */
@@ -142,8 +144,8 @@ export type DropdownProps<T> = {
   placeHolder?: string;
   /** Custom component used to override the default appearance of the list items. */
   optionRenderer?:
-    | React.Component<OptionRendererProps<T>, any>
-    | React.FunctionComponent<OptionRendererProps<T>>;
+  | React.Component<OptionRendererProps<T>, any>
+  | React.FunctionComponent<OptionRendererProps<T>>;
   /** Handle blur events on the control */
   onBlur?: (e) => any;
   /** Handle key down events on the select */
@@ -170,8 +172,8 @@ export type DropdownProps<T> = {
   tabSelectsValue?: boolean;
   /** Custom component used to override the default appearance of the dropdown select input item/s */
   tagRenderer?:
-    | React.Component<TagRendererProps<T>, any>
-    | React.FunctionComponent<TagRendererProps<T>>;
+  | React.Component<TagRendererProps<T>, any>
+  | React.FunctionComponent<TagRendererProps<T>>;
   /** Message to be display on the header of the menu list when searching by term */
   termSearchMessage?: ((term: string) => string) | string;
   /** Color variant of the dropdown */


### PR DESCRIPTION
**APP-4919: Fix displayed option label in Dropdown (multi select)**

https://perzoinc.atlassian.net/browse/APP-4919

When using `Dropdown` (with `isMultiSelect` being `true`), and providing options that does not include a `label` attribute, the option labels are not displayed.

- adds `bindLabel` prop in `Dropdown`, so we can define a way to get the label from an option (default being `(option) => option.label`)
- plugs this `bindLabel` prop to the `getOptionLabel` prop of the `DropdownTag`
- updates the `MultiValue` custom renderer so that it calls `getOptionLabel(option)` instead of `option.label`
- adds related tests

-----

**Before**

https://user-images.githubusercontent.com/66251236/153578986-201aa3a6-f028-443e-9d53-1f038ca8db67.mov

-----

**After**

https://user-images.githubusercontent.com/66251236/153579018-4ab3c8c5-e3cb-4c46-988c-a3e6583ba725.mov