### PR TITLE
Fixing padding for menuDropdownItem

### DIFF
--- a/packages/styles/src/components/atoms/_dropdown-menu.scss
+++ b/packages/styles/src/components/atoms/_dropdown-menu.scss
@@ -3,6 +3,7 @@ $list-font-size-icon: toRem(16);
 .tk-dropdown-menu {
   @include listStyle;
 
+  width: max-content;
   z-index: $z-index-dropdown-menu;
   padding: toRem(8) 0;
   i {
@@ -16,7 +17,7 @@ $list-font-size-icon: toRem(16);
     font-size: toRem(14);
     height: toRem(32);
     line-height: toRem(20);
-    padding: toRem(6) toRem(0) toRem(6) toRem(16);
+    padding: toRem(6) toRem(16) toRem(6) toRem(16);
 
     &--loading {
       display: flex;


### PR DESCRIPTION
There needs to be padding on the right side or the text is super close to the edge.

See Figma SDS for reference - https://www.figma.com/file/V0VKw74594EyCKHwqYk6LV/%E2%9D%96-SDS-Core-Component-Library?node-id=3575%3A99

Before:
<img width="182" alt="Screenshot 2022-02-21 at 16 14 24" src="https://user-images.githubusercontent.com/60875212/154982637-8968ce68-b71f-4888-a7cb-16ba3418a885.png">
<img width="232" alt="Screenshot 2022-02-21 at 16 18 42" src="https://user-images.githubusercontent.com/60875212/154983417-75b264c5-9b8e-4a61-ae72-5ce0a616bcc9.png">


After:
<img width="204" alt="Screenshot 2022-02-21 at 16 14 31" src="https://user-images.githubusercontent.com/60875212/154982652-65e94def-fd6c-482e-8d38-cbe26088b951.png">
<img width="250" alt="Screenshot 2022-02-21 at 16 18 36" src="https://user-images.githubusercontent.com/60875212/154983424-178d9ac2-e665-4077-b4e9-158975765fad.png">

