### PR TITLE
style(dropdown): make the color input style more robust

### DIFF
--- a/packages/styles/src/uitoolkit-components/_select.scss
+++ b/packages/styles/src/uitoolkit-components/_select.scss
@@ -79,10 +79,6 @@ body {
 
       &--menu-is-open,
       &--menu-is-focused {
-        color: getColor(
-          $--tk-input-color,
-          filledText
-        );
         .tk-input__icon {
           color: getColor($graphite, '50');
         }
@@ -176,6 +172,12 @@ body {
       .tk-select__value-container {
         cursor: text;
         padding:0;
+        .tk-select__input {
+          color: getColor(
+            $--tk-input-color,
+            filledText
+          );
+        }
         &--is-multi {
           min-height: var(--tk-select__value-container--is-multi-min-height);
           gap: var(--tk-select__value-container--is-multi-gap);


### PR DESCRIPTION
## Ticket
https://perzoinc.atlassian.net/browse/C2-14729

## Description
Apply the color to `.tk-select__input` instead of `.tk-select__control--menu-is-open` `.tk-select__control--menu-is-focus`

## Demo
![image](https://user-images.githubusercontent.com/56824367/155131989-48793024-2b72-4c4b-929b-4d069351509b.png)

![image](https://user-images.githubusercontent.com/56824367/155131414-e90aa58a-0f57-47da-8a69-a5407388ac93.png)
