### PR TITLE
Allow modal to accept html props

### DIFF
--- a/packages/components/src/components/modal/Modal.tsx
+++ b/packages/components/src/components/modal/Modal.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { Keys } from '../common/eventUtils';
 
-type ModalProps = {
+interface ModalProps extends Omit<React.HTMLProps<HTMLDivElement>, 'size'> {
   size: 'small' | 'medium' | 'large' | 'full-width';
   className?: string;
   children?: React.ReactNode;
@@ -11,7 +11,7 @@ type ModalProps = {
   parentNode?: Element;
   show?: boolean;
   onClose?: () => void;
-};
+}
 
 type ModalContentProps = {
   className?: string;


### PR DESCRIPTION
## Description

The modal component has a hardcoded tabIndex "-1", there is no way to change it as it currently does not accept regular html props.  This prevents us from focusing the modal using sequential keyboard navigation. 

## JIRA ticket

[JIRA_Ticket](https://perzoinc.atlassian.net/jira/software/c/projects/RTC/boards/91?modal=detail&selectedIssue=RTC-9700&quickFilter=5206t)

