### PR TITLE
APP-4818: Fix Dropdown's `...otherProps`

### DIFF
--- a/packages/components/spec/components/dropdown/Dropdown.spec.tsx
+++ b/packages/components/spec/components/dropdown/Dropdown.spec.tsx
@@ -7,9 +7,9 @@ import { Button, Validation } from '../../../src/components';
 import { Validators } from '../../../src/core/validators/validators';
 import { Keys } from '../../../src/components/common/eventUtils';
 
-const CustomComponent = (props) => {
-  if (props.data) {
-    return (<div>{props?.data?.label}</div>);
+const CustomComponent = ({ data }: any) => {
+  if (data) {
+    return (<div>{data?.label}</div>);
   }
 }
 const filterFunction = (element: any, input: string) => {
@@ -17,6 +17,7 @@ const filterFunction = (element: any, input: string) => {
 };
 
 const onChange = jest.fn();
+const onInit = jest.fn();
 const onTermSearch = jest.fn();
 const onClear = jest.fn();
 const onBlur = jest.fn();
@@ -85,7 +86,7 @@ describe('Dropdown component test suite =>', () => {
         expect(screen.getByText('no options message')).toBeTruthy();
       });
 
-      it('should render costum render dropdown', async () => {
+      it('should render custom render dropdown', async () => {
         const { container, getByText } = render(
           <Dropdown
             isMultiSelect
@@ -108,7 +109,6 @@ describe('Dropdown component test suite =>', () => {
         expect(onClear).toBeCalled();
         expect(getByText('Select...')).toBeTruthy();
       });
-
 
       it('should support custom option structure', async () => {
         const customOptions = [
@@ -140,6 +140,16 @@ describe('Dropdown component test suite =>', () => {
         expect(getByText('Case')).toBeInTheDocument();
         expect(queryByText('Hill')).not.toBeInTheDocument();
         expect(queryByText('Conda')).not.toBeInTheDocument();
+      });
+
+      it('should allow prop propagation (otherProps)', async () => {
+        const { getByTestId } = render(<Dropdown options={dropdownProps.options} data-testid="another-prop" />);
+        expect(getByTestId('another-prop')).toBeInTheDocument();
+      });
+
+      it('should call onInit function at load if provided', async () => {
+        render(<Dropdown options={dropdownProps.options} onInit={onInit} value="value" />);
+        expect(onInit).toHaveBeenCalledWith('value');
       });
     });
 
@@ -310,6 +320,7 @@ describe('Dropdown component test suite =>', () => {
         const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions />);
         expect(getByText('Select...')).toBeInTheDocument();
       });
+
       it('should render the `asyncOptions` to the dropdown menu', async () => {
         const { getByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} defaultOptions />);
         const input = screen.getByRole('textbox');
@@ -320,6 +331,7 @@ describe('Dropdown component test suite =>', () => {
           expect(getByText('orange')).toBeTruthy();
         })
       });
+
       it('should filter the `asyncOptions` if user types on the input', async () => {
         const { queryByText } = render(<Dropdown asyncOptions={() => Promise.resolve(options)} />);
         const input = screen.getByRole('textbox');

--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -134,13 +134,21 @@ export class Dropdown<T = LabelValue> extends React.Component<
       displayArrowIndicator,
       DropdownTag,
     } = this.state;
+
     const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      asyncOptions,
       autoScrollToCurrent,
+      bindLabel,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      bindValue,
       blurInputOnSelect,
       className,
       defaultOptions,
       defaultValue,
       enableTermSearch,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      filterFunction,
       iconName,
       id,
       inputAlwaysDisplayed,
@@ -148,6 +156,10 @@ export class Dropdown<T = LabelValue> extends React.Component<
       isDisabled,
       isInputClearable,
       isMultiSelect,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      isOptionDisabled,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      isOptionSelected,
       isTypeAheadEnabled,
       label,
       maxHeight,
@@ -163,6 +175,12 @@ export class Dropdown<T = LabelValue> extends React.Component<
       noOptionMessage,
       placeHolder,
       helperText,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      onBlur,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      onChange,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      onClear,
       onCopy,
       onCut,
       onDrag,
@@ -172,7 +190,11 @@ export class Dropdown<T = LabelValue> extends React.Component<
       onKeyUp,
       onMenuOpen,
       onMenuClose,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      onTermSearch,
       optionRenderer,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      options,
       showRequired,
       size,
       tabSelectsValue,
@@ -182,14 +204,12 @@ export class Dropdown<T = LabelValue> extends React.Component<
       tooltipCloseLabel,
       value,
       variant,
-      bindLabel,
       ...otherProps
     } = this.props;
 
     return (
       <div className={classNames(className, 'tk-input-group', `tk-input-group--${size}`)}>
         <DropdownTag
-          {...otherProps}
           styles={{
             menuPortal: (base: CSSProperties) => ({ ...base, ...menuPortalStyles }),
             valueContainer: (base: CSSProperties) => ({
@@ -267,6 +287,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           menuPortalTarget={menuPortalTarget}
           menuShouldBlockScroll={menuShouldBlockScroll}
           menuShouldScrollIntoView={menuShouldScrollIntoView}
+          {...otherProps}
         />
         <LabelTooltipDecorator
           htmlFor={id}


### PR DESCRIPTION
**APP-4818: Fix Dropdown's `...otherProps`**

This commit makes the `Dropdown` props override possible, by placing the `...otherProps` at the end of the `DropdownTag`.

- All the known props are now extracted from `this.props` (so we don't have any residual known props in `otherProp`)
- All the inner functions are now in the `render` method (to avoid tslint unused var warning)
- Adds related unit test
- Adds unit test for `onInit` prop

Related ticket: https://perzoinc.atlassian.net/browse/APP-4918

--------

![Screenshot 2022-03-10 at 14 39 58](https://user-images.githubusercontent.com/66251236/157673736-a8374e27-754f-41b7-b86d-f845befb686f.png)
