### PR TITLE
Change text color in modal to align with design system

### DIFF
--- a/packages/styles/src/components/atoms/_dialog.scss
+++ b/packages/styles/src/components/atoms/_dialog.scss
@@ -35,7 +35,7 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   border-radius: toRem(8);
   width: toRem(480); // Default medium
   padding: toRem(24) toRem(32);
-  color: $--tk-main-text-color;
+  color: $--tk-modal-text-color;
 
   /* Size variants */
   &--small {

--- a/packages/styles/src/variables/themes/accessors/colors/_index.scss
+++ b/packages/styles/src/variables/themes/accessors/colors/_index.scss
@@ -10,6 +10,8 @@ $--tk-color-error: var(--tk-color-error, $scolor-red);
 
 $--tk-main-text-color: var(--tk-main-text-color, $scolor-graphite);
 
+$--tk-modal-text-color: var(--tk-modal-text-color, getColor($graphite, '80'));
+
 $--tk-outline-color: #88c0fb;
 
 $--tk-background: var(--tk-background, $scolor-white);


### PR DESCRIPTION
## Description

The current text color in modal is not aligned with the design system. See the comments from designer in https://perzoinc.atlassian.net/jira/software/c/projects/RTC/boards/91?modal=detail&selectedIssue=RTC-9700&quickFilter=5206 for more details.

