### PR TITLE
APP-4916: Add CreatableSelect and CreatableAsyncSeelct to the Dropdown component

### DIFF
--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
 import Select, { ActionMeta, createFilter } from 'react-select';
+import CreatableSelect from 'react-select/creatable';
 import AsyncSelect from 'react-select/async';
+import AsyncCreatableSelect from 'react-select/async-creatable';
+
 import {
   ClearIndicator,
   Control,
@@ -37,23 +40,25 @@ export class Dropdown<T = LabelValue> extends React.Component<
   lastSelectedOption: any;
   constructor(props) {
     super(props);
+
     this.myRef = React.createRef();
     this.searchHeaderOption = { ...firstOption };
+
+    const {
+      asyncOptions,
+      addNewOptions,
+      isMultiSelect,
+      hideSelectedOptions,
+      closeMenuOnSelect,
+      displayArrowIndicator,
+    } = this.props;
+
     this.state = {
-      DropdownTag: this.props.options ? Select : AsyncSelect,
+      DropdownTag: this.getDropdownTag(asyncOptions, addNewOptions),
       selectedOption: null,
-      hideSelectedOptions:
-        this.props.hideSelectedOptions === undefined
-          ? this.props?.isMultiSelect
-          : this.props.hideSelectedOptions,
-      closeMenuOnSelect:
-        this.props.closeMenuOnSelect === undefined
-          ? !this.props?.isMultiSelect
-          : this.props.closeMenuOnSelect,
-      displayArrowIndicator:
-        this.props.displayArrowIndicator === undefined
-          ? !this.props?.isMultiSelect
-          : this.props.displayArrowIndicator,
+      hideSelectedOptions: hideSelectedOptions || isMultiSelect,
+      closeMenuOnSelect: closeMenuOnSelect || !isMultiSelect,
+      displayArrowIndicator: displayArrowIndicator || !isMultiSelect,
     };
   }
 
@@ -62,6 +67,18 @@ export class Dropdown<T = LabelValue> extends React.Component<
     if (onInit && value) {
       onInit(value as any);
     }
+  }
+
+  getDropdownTag = (asyncOptions, addNewOptions) => {
+    let DropdownTag: any = Select;
+    if (asyncOptions && !addNewOptions) {
+      DropdownTag = AsyncSelect;
+    } else if (asyncOptions && addNewOptions) {
+      DropdownTag = AsyncCreatableSelect;
+    } else if (!asyncOptions && addNewOptions) {
+      DropdownTag = CreatableSelect;
+    }
+    return DropdownTag;
   }
 
   handleChange = (selectedOption, meta: ActionMeta<T>) => {
@@ -305,6 +322,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
   static defaultProps = {
     isDisabled: false,
     isMultiSelect: false,
+    addNewOptions: false,
     isInputClearable: false,
     isTypeAheadEnabled: true,
     autoScrollToCurrent: false,

--- a/packages/components/src/components/dropdown/interfaces.ts
+++ b/packages/components/src/components/dropdown/interfaces.ts
@@ -67,6 +67,16 @@ type AsyncProps<T> = {
    */
   defaultOptions?: DropdownOption<T>[] | boolean;
 } & HasValidationProps<T>;
+
+type CreatableProps<T> = {
+  /** Decides if the user can create new options at runtime */
+  addNewOptions?: boolean;
+  /** Function returning the created option based on the input value */
+  getNewOptionData?: (inputValue: string) => T,
+  /** Function telling if the inputValue can be converted into a new option */
+  isValidNewOption?: (inputValue: string, value: any[], options: DropdownOption<any>[]) => boolean,
+} & HasValidationProps<T>;
+
 type SyncProps<T> = {
   /** Array of options that populate the dropdown menu */
   options: DropdownOption<T>[];
@@ -182,4 +192,5 @@ export type DropdownProps<T> = {
   MenuPortalProps &
   HasTooltipProps &
   (MultiModeProps<T> | SingleModeProps<T>) &
-  (AsyncProps<T> | SyncProps<T>);
+  (AsyncProps<T> | SyncProps<T>) &
+  CreatableProps<T>;

--- a/packages/components/stories/Dropdown.stories.tsx
+++ b/packages/components/stories/Dropdown.stories.tsx
@@ -19,7 +19,7 @@ const defaultOptions: LabelValue[] = [
   { label: 'Option 5', value: '5' },
   {
     label:
-    'Option Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse elementum gravida neque, suscipit ornare ex pulvinar id. Etiam vitae erat at dolor pharetra suscipit. Donec at nunc malesuada',
+      'Option Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse elementum gravida neque, suscipit ornare ex pulvinar id. Etiam vitae erat at dolor pharetra suscipit. Donec at nunc malesuada',
     value: 'long',
   },
 ];
@@ -101,7 +101,7 @@ const iconData: DropdownOption<Icon>[] = [
 const IconPickerTagRenderer = (props: TagRendererProps<Icon>) => {
   const { data, remove } = props;
   return (
-    <div style={{backgroundColor: 'rgba(0, 200, 0, 0.5)', borderRadius: '4px', padding: '0 4px'}}>
+    <div style={{ backgroundColor: 'rgba(0, 200, 0, 0.5)', borderRadius: '4px', padding: '0 4px' }}>
       {data.displayName}
       <Icon className="tk-pl-1" iconName={data.displayName} />
       <Icon className="tk-ml-1" iconName="cross" onClick={remove} />
@@ -153,7 +153,7 @@ export const Variants: React.FC = () => (<>
   <Dropdown options={defaultOptions} />
   <h4>Destructive</h4>
   <Dropdown options={defaultOptions} variant="destructive" />
-  <div className="tk-py-5"/><div className="tk-py-5"/>
+  <div className="tk-py-5" /><div className="tk-py-5" />
 </>
 );
 
@@ -162,10 +162,10 @@ export const Sizes: React.FC = () => (
     <h4>Small</h4>
     <div style={{ display: 'flex' }}>
       <div style={{ width: '384px', marginRight: '32px' }}>
-        <Dropdown options={defaultOptions} size="small" label="Field label"  isInputClearable/>
+        <Dropdown options={defaultOptions} size="small" label="Field label" isInputClearable />
       </div>
       <div style={{ width: '384px' }}>
-        <Dropdown options={defaultOptions} isMultiSelect size="small" label="Field label"  isInputClearable/>
+        <Dropdown options={defaultOptions} isMultiSelect size="small" label="Field label" isInputClearable />
       </div>
     </div>
     <h4>Medium</h4>
@@ -174,19 +174,19 @@ export const Sizes: React.FC = () => (
         <Dropdown options={defaultOptions} size="medium" label="Field label" isInputClearable />
       </div>
       <div style={{ width: '384px' }}>
-        <Dropdown options={defaultOptions} isMultiSelect size="medium" label="Field label"  isInputClearable />
+        <Dropdown options={defaultOptions} isMultiSelect size="medium" label="Field label" isInputClearable />
       </div>
     </div>
     <h4>Large</h4>
     <div style={{ display: 'flex' }}>
       <div style={{ width: '384px', marginRight: '32px' }}>
-        <Dropdown options={defaultOptions} size="large" label="Field label"  isInputClearable />
+        <Dropdown options={defaultOptions} size="large" label="Field label" isInputClearable />
       </div>
       <div style={{ width: '384px' }}>
-        <Dropdown options={defaultOptions} isMultiSelect size="large" label="Field label" isInputClearable/>
+        <Dropdown options={defaultOptions} isMultiSelect size="large" label="Field label" isInputClearable />
       </div>
     </div>
-    <div className="tk-py-5"/><div className="tk-py-5"/>
+    <div className="tk-py-5" /><div className="tk-py-5" />
   </>
 );
 
@@ -209,12 +209,12 @@ export const Select: React.FC = () => (
       With <strong>tooltip</strong>:
     </p>
     <Dropdown options={defaultOptions} tooltip="Hint to help the user" tooltipCloseLabel="Got it" />
-    
+
     <p className="tk-mt-4">
       With <strong>helperText</strong>:
     </p>
     <Dropdown options={defaultOptions} helperText="Helper text" />
-    
+
     <p className="tk-mt-4">
       Clear selection with <strong>isInputClearable</strong>:
     </p>
@@ -251,11 +251,11 @@ export const Select: React.FC = () => (
     <p>With the <strong>maxHeight</strong> prop you can control the height of the multiple selection before scrolling on the input.</p>
     <Dropdown options={personSelectorOptions} isMultiSelect maxHeight={70} placeHolder="Search for People" isInputClearable noOptionMessage={'No options'} />
 
-    <h2 className="tk-mt-5h">Loading options</h2>
+    <h2 className="tk-mt-5h">Async loading options</h2>
     <p>Use the <strong>asyncOptions</strong> prop to load options from a remote source as the user starts typing on the input.</p>
     <p>The <strong>asyncOptions</strong> prop:</p>
     <h3>defaultOptions</h3>
-    <p>The <strong>defaultOptions</strong> prop is enabled by default (The options are iniatially loaded).</p>
+    <p>The <strong>defaultOptions</strong> prop is enabled by default (The options are initially loaded).</p>
     <Dropdown asyncOptions={promiseOptions} placeHolder="Async select" isInputClearable noOptionMessage={'No options'} />
     <p>* To disable: <strong>defaultOptions=false</strong>. (Start typing to load the options)</p>
     <Dropdown defaultOptions={false} asyncOptions={promiseOptions} maxHeight={70} placeHolder="Async select" isInputClearable noOptionMessage={'No options'} />
@@ -263,6 +263,59 @@ export const Select: React.FC = () => (
     <Dropdown asyncOptions={promiseOptions} isMultiSelect placeHolder="Async select" isInputClearable noOptionMessage={'No options'} />
     <h3>Loading with term search enabled</h3>
     <Dropdown asyncOptions={promiseOptions} placeHolder="Async select" enableTermSearch termSearchMessage="Term: " />
+
+    <h2 className="tk-mt-5h">Creatable options</h2>
+    <p>Use the <strong>addNewOptions</strong> prop to let the user create option at runtime. An option will be created, based on the input value, and be added the option list.</p>
+    <h3>Default</h3>
+    <Dropdown
+      addNewOptions
+      options={defaultOptions}
+      noOptionMessage="No options"
+      placeHolder="Please type a word"
+    />
+    <h3>isValidNewOption (optional)</h3>
+    <p>The <strong>isValidNewOption</strong> prop is optional. By default, any new option is valid.</p>
+    <p>In this example, we only let the user create option containing the character <i>O</i>, and not already part of the existing options:</p>
+    <Dropdown
+      addNewOptions
+      options={defaultOptions}
+      noOptionMessage="No options, please type a word with the character 'O' to create a new option"
+      placeHolder="Please type a word with the character 'O'"
+      isValidNewOption={(inputValue, value, options) => {
+        const includesA = inputValue?.includes('O');
+        const isExisting = options?.map((option) => option.label).includes(inputValue);
+        return includesA && !isExisting;
+      }} />
+    <h3>getNewOptionData (optional)</h3>
+    <p>The <strong>getNewOptionData</strong> prop is optional. By default, the created option will have this structure: &#123; value: <i>inputValue</i>, label: <i>inputValue</i> &#125;.</p>
+    <p>In this example, we use options having <strong>id/name</strong> instead of value/label, and we create option having the structure &#123; id: <i>inputValue</i>, name: <i>inputValue</i> &#125;:</p>
+    <Dropdown
+      addNewOptions
+      options={[
+        { id: 'id1', name: 'Name 1' },
+        { id: 'id2', name: 'Name 2' },
+        { id: 'id3', name: 'Name 3' },
+      ]}
+      bindLabel={(option) => option.name}
+      placeHolder="Please type a word"
+      noOptionMessage="No options"
+      getNewOptionData={(inputValue) => ({ id: inputValue, name: inputValue })}
+    />
+    <h3>With multi-selection</h3>
+    <Dropdown
+      addNewOptions
+      isMultiSelect
+      options={defaultOptions}
+      placeHolder="Please type a word to load options"
+      noOptionMessage="No options"
+    />
+    <h3>With async options loading</h3>
+    <Dropdown
+      addNewOptions
+      asyncOptions={promiseOptions}
+      placeHolder="Please type a word to load options"
+      noOptionMessage="No options"
+    />
 
     <h2 className="tk-mt-5h">Customized selects</h2>
     <p>
@@ -277,7 +330,7 @@ export const Select: React.FC = () => (
       tagRenderer={IconPickerRenderer}
       onTermSearch={onTermSearch}
     />
-    <br/>
+    <br />
     <Dropdown
       options={iconData}
       optionRenderer={IconPickerRenderer}


### PR DESCRIPTION
**APP-4916: Add `CreatableSelect` and `CreatableAsyncSeelct` to the `Dropdown` component**

This commit adds a new `isCreatable` prop to the `Dropdown` component.
When this prop is `true`, the user can create new options at runtime, according to the inputValue. This is compatible with simple selects, multi select and async selects.

Optionally, 2 other props can be provided along with this `isCreatable` prop:
- `getNewOptionData`: function telling how to structure the created option based on the user input (default one will create options using this structure `{ value: $userInput, label: $userInput }`)
- `isValidNewOption`: function telling if the inputValue can be converted into a new option (default one always returns `true`)

Briefly:
- the `DropdownTag` is now chosen according to the `isCreatable` and `asyncOptions` props (see `Dropdown.tsx`)
- adds related interfaces (see `CreatableProps<T>` in `interfaces.ts`)
- adds related unit tests (see `Dropdown.spec.tsx`)
- adds related stories (see `Dropdown.stories.tsx`)

Related ticket: https://perzoinc.atlassian.net/browse/APP-4916

----------

**Preview**

https://user-images.githubusercontent.com/66251236/157677568-28891a13-05ed-42c7-b37e-658b976fe05c.mov


**Full Video**

https://drive.google.com/file/d/1olYAe41dr8bWm6IrKMBWYsN5jE6X1YAe/view?usp=sharing