### PR TITLE
doc(checkbox): add types documentation

### DIFF
--- a/packages/components/src/components/selection/Checkbox.tsx
+++ b/packages/components/src/components/selection/Checkbox.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import SelectionTypes from './SelectionTypes';
-import { SelectionInput, SelectionInputPropTypes } from './SelectionInput';
+import { SelectionInput, SelectionInputProps, SelectionInputPropTypes } from './SelectionInput';
 
-const Checkbox = (props) => {
+const Checkbox = (props: SelectionInputProps) => {
   return <SelectionInput type={SelectionTypes.CHECKBOX} {...props} />;
 };
 

--- a/packages/components/src/components/selection/Radio.tsx
+++ b/packages/components/src/components/selection/Radio.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import SelectionTypes from './SelectionTypes';
-import { SelectionInput, SelectionInputPropTypes } from './SelectionInput';
+import { SelectionInput, SelectionInputProps, SelectionInputPropTypes } from './SelectionInput';
 
-const Radio = (props) => {
+const Radio = (props: SelectionInputProps) => {
   return <SelectionInput type={SelectionTypes.RADIO} {...props} />;
 };
 

--- a/packages/components/stories/Checkbox.stories.tsx
+++ b/packages/components/stories/Checkbox.stories.tsx
@@ -4,8 +4,9 @@ import { Checkbox } from '../src/components';
 import LabelPlacements from '../src/components/selection/LabelPlacements';
 import SelectionStatus from '../src/components/selection/SelectionStatus';
 import { action } from '@storybook/addon-actions';
+import { SelectionInput, SelectionInputProps } from '../src/components/selection/SelectionInput';
 
-const Template = (args) => (<Checkbox {...args} />);
+const Template = (args: SelectionInputProps) => (<Checkbox {...args} />);
 
 export const Default = Template.bind({});
 Default.args = {
@@ -219,4 +220,5 @@ export const Checkboxes = () => {
 export default {
   title: 'Components/Input/Checkbox',
   component: Checkbox,
+  subcomponents: { SelectionInput }
 };

--- a/packages/components/stories/Radio.stories.tsx
+++ b/packages/components/stories/Radio.stories.tsx
@@ -4,8 +4,9 @@ import { Radio } from '../src/components';
 import LabelPlacements from '../src/components/selection/LabelPlacements';
 import { action } from '@storybook/addon-actions';
 import SelectionStatus from '../src/components/selection/SelectionStatus';
+import { SelectionInput } from '../src/components/selection/SelectionInput';
 
-const Template = (args) => (<Radio {...args} />);
+const Template = (args: SelectionStatus) => (<Radio {...args} />);
 
 export const Default = Template.bind({});
 Default.args = {
@@ -159,5 +160,5 @@ export const Radios = () => {
 export default {
   title: 'Components/Input/Radio',
   component: Radio,
-  decorators: [],
+  subcomponents: { SelectionInput }
 };


### PR DESCRIPTION
## Description

Checkbox & Radio: add types in the documentation

SelectionInput already had the props type, but not the Checkbox and Radio
This is not a breaking change, as these component were already restrited to the types (implictly from SelectionInput). I am just making it explicit

## Demo
Before
![image](https://user-images.githubusercontent.com/56824367/157249903-5cbb8d5f-a46e-4585-8004-f889da91b53e.png)
![image](https://user-images.githubusercontent.com/56824367/157250313-65b8df3e-ace7-4fb1-8612-ce4986a76019.png)

After
![image](https://user-images.githubusercontent.com/56824367/157249849-5b8854ec-5b03-454d-983a-eb9fc66cad34.png)
![image](https://user-images.githubusercontent.com/56824367/157250328-8bfe1006-4bba-44ef-9d7b-fa5cdb35d8a4.png)
