### PR TITLE
APP-5102: Align simple and multi select right icon

### DIFF
--- a/packages/components/src/components/dropdown/CustomRender.tsx
+++ b/packages/components/src/components/dropdown/CustomRender.tsx
@@ -112,7 +112,7 @@ export const MultiValueContainerOverride = ({ children, ...props }: any) =>
  * The displayArrowIndicator prop from the Dropdown can override it
  */
 export const DropdownIndicator = (props: any) => {
-  const { isMulti, displayArrowIndicator, menuIsOpen } = props?.selectProps;
+  const { displayArrowIndicator, menuIsOpen } = props?.selectProps;
 
   return !displayArrowIndicator ?
     null :
@@ -120,10 +120,10 @@ export const DropdownIndicator = (props: any) => {
       {...props}
       innerProps={{ 'data-testid': props.selectProps['data-testid'] }}
     >
-      {!isMulti && <Icon
+      <Icon
         className="tk-select__single-value"
         iconName={menuIsOpen ? 'drop-up' : 'drop-down'}
-      />}
+      />
     </components.DropdownIndicator>;
 };
 


### PR DESCRIPTION
## Description

A Dropdown with `isMultiSelect` being `false`, always render a caret icon on the right.
When `isMultiSelect` is `true`, we need to set `displayArrowIndicator` to `true` as well if we want to have an icon on the right. Unfortunately, simple select uses a caret, and multi select uses an arrow.
This commit set the multi select icon to be a caret.

## JIRA ticket

https://perzoinc.atlassian.net/browse/APP-5102

## Demo

**Before**

<img width="700" alt="Screenshot 2022-04-28 at 18 01 49" src="https://user-images.githubusercontent.com/66251236/165796821-8b934133-b51c-40a8-a617-420e12d3e8df.png">

**After**

<img width="702" alt="Screenshot 2022-04-28 at 17 59 32" src="https://user-images.githubusercontent.com/66251236/165796816-6de884a7-799e-4499-b673-15ebe75cc255.png">

