### PR TITLE
APP-5103: Fix multi select option overflow

### DIFF
--- a/packages/styles/src/uitoolkit-components/_select.scss
+++ b/packages/styles/src/uitoolkit-components/_select.scss
@@ -105,6 +105,9 @@ body {
             $--tk-select-tag-color,
             default
           );
+          & > div {
+            width: 100%;
+          }
           &__label {
             display: flex;
             align-items: center;
@@ -186,6 +189,7 @@ body {
             display: flex;
             align-items: center;
             max-width: toRem(192);
+            width: 100%;
             .tk-tag {
               padding-right: toRem(4);
               max-width: toRem(200);


### PR DESCRIPTION
## Description

When using the `Dropdown` component with `displayArrowIndicator` and `isMultiSelect`, the remove option button is displayed in overflow and not completely visible. This issue is fixed by this commit.

## JIRA ticket

https://perzoinc.atlassian.net/browse/APP-5103

## Demo

**Before**

![Screenshot 2022-04-29 at 09 30 10](https://user-images.githubusercontent.com/66251236/165911031-09832e2e-6234-4612-8883-72ede8f44285.png)

**After**

![Screenshot 2022-04-29 at 09 37 07](https://user-images.githubusercontent.com/66251236/165911051-97cea22d-78e7-40f1-b893-f54c0f9542e3.png)