### PR TITLE
APP-5149 Disable temporary Visual Tests in Dark mode

### DIFF
--- a/packages/styles/.circleci/config.yml
+++ b/packages/styles/.circleci/config.yml
@@ -69,11 +69,13 @@ jobs:
           when: always
           command: |
             yarn test --config .creevey/config_condensed.js
-      - run:
-          name: Execute Visual Tests - Dark Mode
-          when: always
-          command: |
-            yarn test --config .creevey/config_darkmode.js
+      # Temporary disable it because it fails randomly...
+      # See ticket https://perzoinc.atlassian.net/browse/APP-5149
+      #- run:
+      #    name: Execute Visual Tests - Dark Mode
+      #    when: always
+      #    command: |
+      #      yarn test --config .creevey/config_darkmode.js
       - run:
           name: Execute Visual Tests - Dark Mode + Condensed
           when: always


### PR DESCRIPTION
Disable temporary Visual Tests in Dark mode

I created the ticket https://perzoinc.atlassian.net/browse/APP-5149 to not forget to fix it.
