### PR TITLE
RTC-13610 Fix Modal drag propagation

### DIFF
--- a/packages/components/spec/components/modal/Modal.spec.tsx
+++ b/packages/components/spec/components/modal/Modal.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Modal, ModalBody, ModalFooter, ModalHeader, ModalTitle } from '../../../src/components';
 import { Keys } from '../../../src/components/common/eventUtils';
-
 import {
   render,
   screen,
@@ -60,7 +59,8 @@ describe('Modal', () => {
     expect(footer).toBeDefined();
     expect(footer.classList).toContain(footerCssClass);
     expect(footer.classList).toContain('tk-dialog__footer');
-  })
+  });
+
   it('should render nothing', () => {
     const titleText = 'Text in title';
     const headerText = 'Text in header';
@@ -82,7 +82,8 @@ describe('Modal', () => {
     expect(queryByText(headerText)).toBeNull();
     expect(queryByText(bodyText)).toBeNull();
     expect(queryByText(footerText)).toBeNull();
-  })
+  });
+
   it('should close the Modal on "Esc"', async () => {
     let show = true;
     const handleClose = () => { show = false }
@@ -106,4 +107,32 @@ describe('Modal', () => {
     // Modal should be closed
     expect(show).toBeFalsy();
   })
+});
+
+it('should not propagate mouse down event by default', async () => {
+  const onMouseDownParent = jest.fn();
+  const component = <div className="parent" onMouseDown={onMouseDownParent}>
+    <Modal size={'small'} show>
+      <ModalTitle>Title</ModalTitle>
+      <ModalHeader>Header</ModalHeader>
+      <ModalBody>Body</ModalBody>
+    </Modal>
+  </div>;
+  render(component);
+  fireEvent.mouseDown(screen.getByText('Title'))
+  expect(onMouseDownParent).not.toHaveBeenCalled();
+});
+
+it('should allow to propagate mouse down event', async () => {
+  const onMouseDownParent = jest.fn();
+  const component = <div className="parent" onMouseDown={onMouseDownParent}>
+    <Modal size={'small'} show onMouseDown={undefined}>
+      <ModalTitle>Title</ModalTitle>
+      <ModalHeader>Header</ModalHeader>
+      <ModalBody>Body</ModalBody>
+    </Modal>
+  </div>;
+  render(component);
+  fireEvent.mouseDown(screen.getByText('Title'))
+  expect(onMouseDownParent).toHaveBeenCalled();
 });

--- a/packages/components/src/components/modal/Modal.tsx
+++ b/packages/components/src/components/modal/Modal.tsx
@@ -57,8 +57,8 @@ const Modal: React.FC<ModalProps> = ({
 }: ModalProps) => {
   const containerClasses = classNames(className, `${prefix}-backdrop`);
   const sizeClasses = classNames(prefix, { [`${prefix}--${size}`]: size });
-  const handleContentClick = (event: React.MouseEvent<HTMLElement>) =>
-    event.stopPropagation();
+  const handleContentClick = (event: React.MouseEvent<HTMLElement>) => event.stopPropagation();
+  const onMouseDown = (event: React.MouseEvent) => event.stopPropagation();
   const handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
     if (onClose && event.key === Keys.ESC) {
       event.stopPropagation();
@@ -68,6 +68,7 @@ const Modal: React.FC<ModalProps> = ({
 
   const domResult = (
     <div
+      onMouseDown={onMouseDown}
       {...rest}
       className={containerClasses}
       onClick={onClose}


### PR DESCRIPTION
When the LeftNav is collapsed, dragging the Symphony-C9 extension Instant Voice "Add user" modal, is also dragging the Instant Voice active call widget simultaneously, this PR fix the issue.

https://perzoinc.atlassian.net/browse/RTC-13610