### PR TITLE
RTC-13661 Allow to disable Modal scrollbar

### DIFF
--- a/packages/components/src/components/modal/Modal.tsx
+++ b/packages/components/src/components/modal/Modal.tsx
@@ -16,6 +16,7 @@ interface ModalProps extends Omit<React.HTMLProps<HTMLDivElement>, 'size'> {
 type ModalContentProps = {
   className?: string;
   children?: React.ReactNode;
+  noScroll?: boolean;
 };
 
 const prefix = 'tk-dialog';
@@ -36,8 +37,9 @@ export const ModalHeader: React.FC<ModalContentProps> = ({
 export const ModalBody: React.FC<ModalContentProps> = ({
   className,
   children,
+  noScroll = false,
   ...rest
-}: ModalContentProps) => <div className={classNames(buildClass('body'), className)} {...rest}>{children}</div>;
+}: ModalContentProps) => <div className={classNames(buildClass('body'), className, { noScroll })} {...rest}>{children}</div>;
 
 export const ModalFooter: React.FC<ModalContentProps> = ({
   className,

--- a/packages/styles/src/components/atoms/_dialog.scss
+++ b/packages/styles/src/components/atoms/_dialog.scss
@@ -53,6 +53,7 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   &--full-width {
     width: 100%;
   }
+
   /* Subcomponents */
   &__title {
     padding-right: toRem(16);
@@ -111,11 +112,16 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
     &::-webkit-scrollbar {
       width: toRem(5);
     }
+
     &::-webkit-scrollbar-thumb {
       border-radius: toRem(5);
       background-color: $dialog-scrollbar-box-shadow;
       // Remove the border, because Mana defines a 4px transparent border that reduces the width of our scrollbar.
       border: none;
+    }
+
+    &.noScroll {
+      overflow: initial;
     }
   }
 


### PR DESCRIPTION
Allow to disable the body scrollbar.

In some use cases we want to manage the scrollbar on a body child element, in that case we need to disable the body scrollbar:
![image](https://user-images.githubusercontent.com/112877883/209137750-9110c27c-9016-45eb-8ef0-0f1267ba77f8.png)

https://perzoinc.atlassian.net/browse/RTC-13661