### PR TITLE
C2-18455 - Add specific CSS class for tk icons

### DIFF
--- a/packages/components/src/components/icon/Icon.tsx
+++ b/packages/components/src/components/icon/Icon.tsx
@@ -35,7 +35,7 @@ const Icon: React.FC<IconProps> = ({
   return (
     <i
       {...otherProps}
-      className={classnames(`tk-icon-${iconName}`, className)}
+      className={classnames(`tk-icon tk-icon-${iconName}`, className)}
       onClick={!disabled ? onClick : null}
       onKeyDown={!disabled ? onKeyDown : null}
       onKeyPress={!disabled ? onKeyPress : null}

--- a/packages/styles/src/icons/_index.scss
+++ b/packages/styles/src/icons/_index.scss
@@ -3,8 +3,7 @@ $ICONS_FONTS_PATH: '~@symphony-ui/uitoolkit-styles/dist/fonts' !default;
 @import './animation';
 @import './generated/tk-icons-definitions';
 
-[class^='tk-icon-'],
-[class*=' tk-icon-'] {
+.tk-icon {
   display: inline-block;
   font-variant: normal;
   font-style: normal;

--- a/packages/styles/src/icons/templates/tk-icons.scss.hbs
+++ b/packages/styles/src/icons/templates/tk-icons.scss.hbs
@@ -9,7 +9,7 @@ url($ICONS_FONTS_PATH+"/tk-icons.ttf") format("truetype"),
 url($ICONS_FONTS_PATH+"/tk-icons.svg#tk-icons") format("svg");
   }
 
-  i[class^="tk-icon-"]:before, i[class*=" tk-icon-"]:before {
+  i.tk-icon:before {
     display: inline-block;
     font-family: {{ name }} !important;
     font-style: normal;

--- a/packages/styles/src/icons/templates/tk-icons.stories.js.hbs
+++ b/packages/styles/src/icons/templates/tk-icons.stories.js.hbs
@@ -9,7 +9,7 @@ export const Icon = () => `
 
         <div class="preview">
             <span class="inner">
-                <{{ ../tag }} class="{{ ../prefix }}-{{ @key }}"></{{ ../tag }}>
+                <{{ ../tag }} class="{{ ../prefix }} {{ ../prefix }}-{{ @key }}"></{{ ../tag }}>
             </span>
             <br>
             <span class='label'>{{ @key }}</span>


### PR DESCRIPTION
## Description

Default CSS selectors with ^= and *= were creating perf bottleneck in C2 mostly because they force the browser to check for every single dom element to match classes against the 2 generic selectors. In a grid with 20 chats this starts to get significant. By adding a dedicated `.tk-icon` class the browser is able to better optimise its recalculate style. 

## JIRA ticket

[C2-18455](https://perzoinc.atlassian.net/browse/C2-18455)

## Demo

![image](https://user-images.githubusercontent.com/69467740/225037162-e5bf171d-3f15-49ce-8093-d25ef632be3a.png)



[C2-18455]: https://perzoinc.atlassian.net/browse/C2-18455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ