### PR TITLE
Fix main entrypoint

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
   },
   "license": "ISC",
   "sideEffects": false,
-  "main": "dist/src/index.js",
+  "main": "index.js",
   "scripts": {
     "prepare": "cd ../.. && husky install",
     "clean": "rm -rf dist",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
   },
   "license": "ISC",
   "sideEffects": false,
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "prepare": "cd ../.. && husky install",
     "clean": "rm -rf dist",


### PR DESCRIPTION
When linking locally with yalc the entrypoint was `dist/src/index.js` but shouldn't have changed it because published `index.js` is correct.

Update: I think `src/index.js` is the most correct.

<img width="517" alt="Screenshot 2023-03-20 at 10 40 04" src="https://user-images.githubusercontent.com/60875212/226301834-a7daa9f6-8b5c-45d0-a6f3-00629cf4f37a.png">
