### PR TITLE
fix(dropdown-menu): reducing icon selector weight

### DIFF
--- a/packages/components/stories/DropdownMenu.stories.tsx
+++ b/packages/components/stories/DropdownMenu.stories.tsx
@@ -18,25 +18,25 @@ export const Default: React.FC = () => (
       <DropdownMenuItem>New room...</DropdownMenuItem>
       <DropdownMenuDivider />
       <DropdownMenuItem>
-        <Icon iconName="minus-round"/>
+        <Icon iconName="minus-round" />
         Cut
       </DropdownMenuItem>
       <DropdownMenuItem>
-        <Icon iconName="copy"/>
+        <Icon iconName="copy" />
         Copy
         <i className="tk-dropdown-menu--selected" />
       </DropdownMenuItem>
       <DropdownMenuItem>
-        <Icon iconName="forward"/>
+        <Icon iconName="forward" />
         Paste
       </DropdownMenuItem>
       <DropdownMenuDivider />
       <DropdownMenuItem>
-        <Icon iconName="fullscreen-on"/>
+        <Icon iconName="fullscreen-on" />
         Full screen
       </DropdownMenuItem>
       <DropdownMenuItem>
-        <Icon iconName="fullscreen-off"/>
+        <Icon iconName="fullscreen-off" />
         Minimize
       </DropdownMenuItem>
     </DropdownMenu>
@@ -100,18 +100,15 @@ export const LoadingState: React.FC = () => {
   return (
     <>
       <h3>Loading State</h3>
-      <Typography>
-        This menu can have loading menu item.
-      </Typography>
+      <Typography>This menu can have loading menu item.</Typography>
       <div className="tk-mb-1" />
-      <DropdownMenu
-        className="dropdownMenu"
-        show
-      >
+      <DropdownMenu className="dropdownMenu" show>
         <DropdownMenuItem>New direct chat</DropdownMenuItem>
         <DropdownMenuItem>New room...</DropdownMenuItem>
         <DropdownMenuDivider />
-        <DropdownMenuItem isLoading>You should never see this text</DropdownMenuItem>
+        <DropdownMenuItem loading>
+          You should never see this text
+        </DropdownMenuItem>
         <DropdownMenuDivider />
         <DropdownMenuItem>
           <Icon iconName="minus-round" className="leftIcon" />
@@ -138,7 +135,7 @@ export const LoadingState: React.FC = () => {
       </DropdownMenu>
     </>
   );
-}
+};
 
 export default {
   title: 'Components/Dropdown Menu',

--- a/packages/styles/src/components/atoms/_dropdown-menu.scss
+++ b/packages/styles/src/components/atoms/_dropdown-menu.scss
@@ -6,11 +6,7 @@ $list-font-size-icon: toRem(16);
   width: max-content;
   z-index: $z-index-dropdown-menu;
   padding: toRem(8) 0;
-  i {
-    color: getColor($--tk-select-color, defaultMenuIcon);
-    font-size: $list-font-size-icon;
-    padding-right: toRem(8);
-  }
+
 
   &__item {
     box-sizing: border-box;
@@ -29,6 +25,12 @@ $list-font-size-icon: toRem(16);
       .tk-loader-spinner {
         padding-right: 0;
       }
+    }
+
+    > i {
+      color: getColor($--tk-select-color, defaultMenuIcon);
+      font-size: $list-font-size-icon;
+      padding-right: toRem(8);
     }
   }
 

--- a/packages/styles/src/utils/mixins/_list.scss
+++ b/packages/styles/src/utils/mixins/_list.scss
@@ -21,7 +21,7 @@ $list-box-shadow: rgba($scolor-graphite-plus-89, 0.122);
     &:not(&--loading):hover {
       color: getColor($--tk-select-color, hoverMenuText);
       background-color: getColor($--tk-select-color, hoverMenuBg);
-      i, i::before {
+      > i, > i::before {
         color: getColor($--tk-select-color, hoverMenuIcon);
       }
     }

--- a/packages/styles/stories/dropdownMenu.stories.js
+++ b/packages/styles/stories/dropdownMenu.stories.js
@@ -5,65 +5,83 @@ export default {
 export const DropdownMenu = () => {
   return `
   <div class="tk-m-4">
-  <h2>Dropdown Menu</h2>
-  <div class="flex-row">
-    <div class="flex-col tk-mr-5h">
-      <h3>Default</h3>
-      <div class="tk-dropdown-menu" style="width:200px">
-        <div class="tk-dropdown-menu__item">New direct chat</div>
-        <div class="tk-dropdown-menu__item">New room...</div>
-        <div class="tk-dropdown-menu-divider"></div>
-        <div class="tk-dropdown-menu__item">Cut</div>
-        <div class="tk-dropdown-menu__item">Copy
-          <i class="tk-dropdown-menu--selected"></i>
-        </div>
-        <div class="tk-dropdown-menu__item">Paste</div>
-        <div class="tk-dropdown-menu-divider"></div>
-        <div class="tk-dropdown-menu__item">Full screen</div>
-        <div class="tk-dropdown-menu__item">Minimize</div>
-      </div>
-    </div>
-    <div class="flex-col tk-mr-5h">
-      <h3>With icons</h3>
-      <div class="tk-dropdown-menu" style="width:200px">
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-plus"></i>
-          New direct chat
-        </div>
-        <div class="tk-dropdown-menu__item">
-        <i class="tk-icon-chats"></i>New room...</div>
-        <div class="tk-dropdown-menu-divider"></div>
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-minus-round"></i>Cut</div>
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-copy"></i>Copy</div>
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-forward"></i>Paste
-          <i class="tk-dropdown-menu--selected"></i>
-        </div>
-        <div class="tk-dropdown-menu-divider"></div>
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-fullscreen-on"></i>Full screen</div>
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-fullscreen-off"></i>Minimize</div>
-      </div>
-    </div>
-    <div class="flex-col">
-      <h3>Expandable</h3>
-      <div class="tk-dropdown-menu" style="width:200px">
-        <div class="tk-dropdown-menu__item">
-          <i class="tk-icon-star"></i>Star</div>
+    <h2>Dropdown Menu</h2>
+    <div class="flex-row">
+      <div class="flex-col tk-mr-5h">
+        <h3>Default</h3>
+        <div class="tk-dropdown-menu" style="width:200px">
+          <div class="tk-dropdown-menu__item">New direct chat</div>
+          <div class="tk-dropdown-menu__item">New room...</div>
           <div class="tk-dropdown-menu-divider"></div>
-        <div class="tk-dropdown-menu__item tk-pl-5">Move to
-        <i class="tk-dropdown-menu--expandable"></i>
+          <div class="tk-dropdown-menu__item">Cut</div>
+          <div class="tk-dropdown-menu__item">Copy
+            <i class="tk-dropdown-menu--selected"></i>
+          </div>
+          <div class="tk-dropdown-menu__item">Paste</div>
+          <div class="tk-dropdown-menu-divider"></div>
+          <div class="tk-dropdown-menu__item">Full screen</div>
+          <div class="tk-dropdown-menu__item">Minimize</div>
         </div>
-        <div class="tk-dropdown-menu-divider"></div>
-        <div class="tk-dropdown-menu__item tk-pl-5">Hide</div>
-        <div class="tk-dropdown-menu__item tk-pl-5">Mute
-          <i class="tk-dropdown-menu--selected"></i>
+      </div>
+      <div class="flex-col tk-mr-5h">
+        <h3>With icons</h3>
+        <div class="tk-dropdown-menu" style="width:200px">
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-plus"></i>
+            New direct chat
+          </div>
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-chats"></i>New room...
+          </div>
+          <div class="tk-dropdown-menu-divider"></div>
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-minus-round"></i>Cut
+          </div>
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-copy"></i>Copy
+          </div>
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-forward"></i>Paste
+            <i class="tk-dropdown-menu--selected"></i>
+          </div>
+          <div class="tk-dropdown-menu-divider"></div>
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-fullscreen-on"></i>Full screen
+          </div>
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-fullscreen-off"></i>Minimize
+          </div>
+        </div>
+      </div>
+      <div class="flex-col">
+        <h3>Expandable</h3>
+        <div class="tk-dropdown-menu" style="width:200px">
+          <div class="tk-dropdown-menu__item">
+            <i class="tk-icon-star"></i>Star
+          </div>
+          <div class="tk-dropdown-menu-divider"></div>
+          <div class="tk-dropdown-menu__item tk-pl-5">
+            Move to
+            <i class="tk-dropdown-menu--expandable"></i>
+            <div class="tk-dropdown-menu" style="width:220px; position: absolute; left: calc(100% - 0.5rem); top: 0.375rem">
+              <div class="tk-dropdown-menu__item tk-pl-5">All Chats</div>
+              <div class="tk-dropdown-menu__item tk-pl-5">Externals</div>
+              <div class="tk-dropdown-menu-divider"></div>
+              <div class="tk-dropdown-menu__item">
+                <i class="tk-icon-open-new-tab"></i>New workspace
+              </div>
+            </div>
+          </div>
+          <div class="tk-dropdown-menu-divider"></div>
+          <div class="tk-dropdown-menu__item tk-pl-5">Hide</div>
+          <div class="tk-dropdown-menu__item tk-pl-5">
+            Mute
+            <i class="tk-dropdown-menu--selected"></i>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
-`}
+`;
+};


### PR DESCRIPTION
It was impossible to implement properly sub menus containing icons, when hovering, the icon style is forced to a light color, that would also apply to all the icons of the sub-menu.

### Before
Icons in sub-menu are light because of hover on the parent menu item

![Screenshot 2023-04-25 at 11 36 39](https://user-images.githubusercontent.com/73846775/234237089-59aeac1f-a92f-442b-b4b4-cb4f42a58713.png)

### After

![Screenshot 2023-04-25 at 11 38 38](https://user-images.githubusercontent.com/73846775/234237605-6c96ec48-d73e-48e6-beba-f823a7300b19.png)

![Screenshot 2023-04-25 at 09 27 43](https://user-images.githubusercontent.com/73846775/234236772-c22a6f42-1144-4c48-972d-7d5dc7644f40.png)

---

I also fixed some markup formatting here and there


cc @antoinerollindev @axeleriksson147 @symphony-jean-michael 