### PR TITLE
React 18 proof types

### DIFF
--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -21,6 +21,7 @@ import {
   ModalTitle,
 } from './modal';
 import { Checkbox, Radio, Switch } from './selection';
+import SelectionStatus from './selection/SelectionStatus';
 import Tooltip, { TooltipProps } from './tooltip';
 import Typography from './typography';
 import Validators from '../core/validators';
@@ -41,6 +42,7 @@ export * from './text-ellipsis';
 export * from './time-picker';
 export * from './toast';
 export * from './validation';
+
 
 export {
   Card,
@@ -66,6 +68,7 @@ export {
   ModalHeader,
   ModalBody,
   ModalFooter,
+  SelectionStatus,
   TkIcon,
   Typography,
   Loader,

--- a/packages/components/src/components/typography/Typography.tsx
+++ b/packages/components/src/components/typography/Typography.tsx
@@ -7,6 +7,7 @@ type variant = 'italic' | 'bold';
 type TypographyProps = {
   type?: 'h1' | 'h2' | 'h3' | 'h4' | 'body' | 'small';
   variant?: variant | variant[] | '';
+  children?: React.ReactNode;
   className?: string;
 };
 

--- a/packages/components/src/components/validation/Validation.tsx
+++ b/packages/components/src/components/validation/Validation.tsx
@@ -19,6 +19,7 @@ const ValidationPropTypes = {
 };
 
 interface ValidationProps {
+  children?: React.ReactNode;
   onValidationChanged?: (
     isValid: boolean,
     errorsMap?: { [id: string]: boolean }

--- a/packages/styles/.circleci/config.yml
+++ b/packages/styles/.circleci/config.yml
@@ -34,8 +34,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
-      - browser-tools/install-chrome:
-        replace-existing-chrome: true
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run: curl -L -O https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.1.0/selenium-server-4.1.1.jar
       - run: yarn

--- a/packages/styles/.circleci/config.yml
+++ b/packages/styles/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+        replace-existing-chrome: true
       - browser-tools/install-chromedriver
       - run: curl -L -O https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.1.0/selenium-server-4.1.1.jar
       - run: yarn

--- a/packages/styles/.circleci/config.yml
+++ b/packages/styles/.circleci/config.yml
@@ -16,7 +16,7 @@ cdn-credentials: &cdn-credentials
 orbs:
   node: circleci/node@2.1
   aws-cli: circleci/aws-cli@2.0
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.4.5
 
 jobs:
   checkout-and-bump: # TODO: Move in a common part


### PR DESCRIPTION
I was looking at upgrading SFE-RTC to React 18 and one thing done is that `children` is not a built in prop anymore. This React 18 proofs UIToolkit.