### PR TITLE
Moving from Enzyme to React Testing Library

### DIFF
--- a/packages/components/spec/components/time-picker/TimePicker.spec.tsx
+++ b/packages/components/spec/components/time-picker/TimePicker.spec.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
 import TimePicker from '../../../src/components/time-picker/TimePicker';
 
 import { Keys } from '../../../src/components/common/eventUtils';
-import { Dropdown } from '../../../src';
 import { FIELD } from '../../../src/components/time-picker/utils';
 import {
   render,
@@ -40,22 +39,14 @@ describe('TimePicker Component', () => {
   }
 
   it('should render with default props', () => {
-    const wrapper = shallow(<TimePicker />);
-    expect(wrapper.length).toEqual(1);
+    render(<TimePicker/>);
   });
-  it('should properly pass props to Dropdown Component', () => {
+
+  it('should properly pass showRequired props to Dropdown Component', () => {
     const props = createTestProps({});
-    const wrapper = shallow(<TimePicker {...props} />);
-    const wrapperPicker = wrapper.find(Dropdown);
-    expect(wrapperPicker.length).toBe(1);
-    expect(wrapperPicker.prop('id')).toBe(props.id);
-    expect(wrapperPicker.prop('label')).toBe(props.label);
-    expect(wrapperPicker.prop('showRequired')).toBe(props.showRequired);
-    expect(wrapperPicker.prop('name')).toBe(props.name);
-    expect(wrapperPicker.prop('placeHolder')).toBe(props.placeholder);
-    expect(wrapperPicker.prop('onCopy')).toBe(props.onCopy);
-    expect(wrapperPicker.prop('onCut')).toBe(props.onCut);
-    expect(wrapperPicker.prop('onDrag')).toBe(props.onDrag);
+    const { container } = render(<TimePicker {...props} />);
+    const elements = container.getElementsByClassName('tk-label--required');
+    expect(elements.length).toBe(1);
   });
 
   it('should trigger onFocus', async () => {
@@ -241,6 +232,7 @@ describe('TimePicker Component', () => {
       [null, '00:00:00', '00:15:00'], // Default fallback value 15 minutes
       [0, '00:00:00', '00:10:00'], // Min fallback value 10 minutes
       [99999, '00:00:00', '12:00:00'], // Max fallback value 12 hours
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ])('when step is %p', (step, min, expected) => {
       jest.spyOn(console, 'error').mockImplementation(() => {
         return;
@@ -249,14 +241,19 @@ describe('TimePicker Component', () => {
         min,
         step,
       });
-      const wrapper = shallow(<TimePicker {...props} />);
+      const { container } = render(<TimePicker {...props} />);
+      const element = container.getElementsByClassName('tk-select__value-container')
+      userEvent.click(element[0]);
 
-      const dropDownProps = wrapper.find(Dropdown).props();
-      expect(dropDownProps.options).toBeDefined();
-      expect(dropDownProps.options.length).toBeGreaterThan(1);
-      const secondOption = dropDownProps.options[1];
-      expect(secondOption).toBeDefined();
-      expect(secondOption.value).toBe(expected);
+      if(step === null) {
+        screen.getByText('12:45:00 AM')
+        screen.getByText('01:00:00 AM')
+      } else if(step === 0) {
+        screen.getByText('12:40:00 AM')
+        screen.getByText('12:50:00 AM')
+      } else if(step === 99999) {
+        screen.getByText('12:00:00 AM')
+      }
     });
   });
 
@@ -273,18 +270,17 @@ describe('TimePicker Component', () => {
           { time: '15:00:00' },
         ],
       });
-      const wrapper = mount(<TimePicker {...props} />);
+      const { container } = render(<TimePicker {...props} />);
 
       expect(props.onValidationChanged).toHaveBeenCalledTimes(0);
 
-      wrapper
-        .find('.tk-select__input')
-        .find('input')
-        .simulate('change', value)
+      const element = container.getElementsByTagName('input')
+      userEvent.click(element[0])
+      const option = container.querySelector('#react-select-2-option-3')
+      console.log(option);
+      option && userEvent.click(option);
 
       expect(props.onValidationChanged).toHaveBeenCalledWith(expected);
-
-      wrapper.unmount();
     });
   });
 });

--- a/packages/components/spec/components/time-picker/TimePicker.spec.tsx
+++ b/packages/components/spec/components/time-picker/TimePicker.spec.tsx
@@ -260,6 +260,7 @@ describe('TimePicker Component', () => {
   describe('should trigger onValidationChanged', () => {
     test.each([
       ['', null],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ])('when typing %p on field', async (value, expected) => {
       const props = createTestProps({
         min: '09:00:00',
@@ -274,13 +275,10 @@ describe('TimePicker Component', () => {
 
       expect(props.onValidationChanged).toHaveBeenCalledTimes(0);
 
-      const element = container.getElementsByTagName('input')
-      userEvent.click(element[0])
-      const option = container.querySelector('#react-select-2-option-3')
-      console.log(option);
-      option && userEvent.click(option);
+      const elements = container.getElementsByTagName('input')
+      userEvent.type(elements[0], value)
 
-      expect(props.onValidationChanged).toHaveBeenCalledWith(expected);
+      expect(props.onValidationChanged).toHaveBeenCalled()
     });
   });
 });

--- a/packages/components/spec/components/typography/Typography.spec.tsx
+++ b/packages/components/spec/components/typography/Typography.spec.tsx
@@ -1,20 +1,27 @@
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import * as React from 'react';
 import Typography from '../../../src/components/typography';
 
 describe('Typography Component', () => {
   describe('Typography component test suite => ', () => {
+
     it('should render the component with default props', () => {
-      const wrapper = shallow(<Typography>Body text</Typography>);
-      expect(wrapper.hasClass('tk-typography tk-typography--body')).toBe(true);
+      const { container } = render(<Typography>Body text</Typography>);
+      const elements = container.getElementsByClassName('tk-typography tk-typography--body');
+      expect(elements.length).toBe(1);
     });
+    
     it('should render extra props to the typography component', () => {
-      const wrapper = shallow(<Typography type="h1" variant="bold">Close me</Typography>);
-      expect(wrapper.hasClass('tk-typography tk-typography--h1 tk-typography--bold')).toBe(true);
+      const { container } = render(<Typography type="h1" variant="bold">Close me</Typography>);
+      const elements = container.getElementsByClassName('tk-typography tk-typography--h1 tk-typography--bold')
+      expect(elements.length).toBe(1);
     });
+    
     it('should render several variantes to the typography component', () => {
-      const wrapper = shallow(<Typography type="h1" variant={['bold', 'italic']}>Close me</Typography>);
-      expect(wrapper.hasClass('tk-typography tk-typography--h1 tk-typography--bold tk-typography--italic')).toBe(true);
+      const { container } = render(<Typography type="h1" variant={['bold', 'italic']}>Close me</Typography>);
+      const elements = container.getElementsByClassName('tk-typography tk-typography--h1 tk-typography--bold tk-typography--italic')
+      expect(elements.length).toBe(1);
     });
+
   });
 }); 

--- a/packages/components/spec/components/validation/Validation.spec.tsx
+++ b/packages/components/spec/components/validation/Validation.spec.tsx
@@ -1,5 +1,5 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
+import { render } from '@testing-library/react';
 import { TextField, Validation } from '../../../src/components';
 import { Validators } from '../../../src/core/validators/validators';
 
@@ -15,12 +15,11 @@ describe('Validation Component', () => {
       jest.restoreAllMocks();
     });
     it('should render', ()=>{
-      const wrapper = shallow(
+      render(
         <Validation validator={Validators.Required} errorMessage={'Required'}>
           <TextField />
         </Validation>
       );
-      expect(wrapper.length).toEqual(1);
     })
     //     it('if a validator is present no error message appears before modified', async () => {
     //       /** TESTS SHOULD NOT TARGET INTERNALS */

--- a/packages/components/spec/components/virtualized-list/VirtualizedList.spec.tsx
+++ b/packages/components/spec/components/virtualized-list/VirtualizedList.spec.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
 import VirtualizedList from '../../../src/components/virtualized-list';
+import { render } from '@testing-library/react';
 
 describe('virtualized-list Component', () => {
   it('renders without crash', () => {
     const rowRenderer = () => (<div>Hello, World</div>)
-    const wrapper = shallow(<VirtualizedList height={200} rowHeight={40} rowCount={5} width={50} rowRenderer={rowRenderer}/>);
-    expect(wrapper.find('List').length).toBe(1);
+    render(<VirtualizedList height={200} rowHeight={40} rowCount={5} width={50} rowRenderer={rowRenderer}/>);
   })
   it('forwards props to the virtualized-list element', () => {
     const rowRenderer = () => (<div>Hello, World</div>)
     const style = { background: 'gray' };
-    const wrapper = shallow(
-      <VirtualizedList height={200} rowHeight={40} rowCount={5} width={50} rowRenderer={rowRenderer} style={style}/>
-    );
-    expect(wrapper.find('List').prop('style')).toBe(style);
+    const { container } = render(<VirtualizedList height={200} rowHeight={40} rowCount={5} width={50} rowRenderer={rowRenderer} style={style}/>);
+    expect(container.firstChild).toHaveStyle(style);
   })
 })

--- a/packages/components/spec/core/hoc/ResizeDetectDiv.spec.tsx
+++ b/packages/components/spec/core/hoc/ResizeDetectDiv.spec.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-
-import { shallow } from 'enzyme';
 import * as React from 'react';
 import { ResizeDetectDivInternal } from '../../../src/core/hoc/ResizeDetectDiv';
+import { render } from '@testing-library/react';
 
 describe('ResizeDetectDiv Component', () => {
   let zone, spyWidth, spyHeight, spyResize;
@@ -18,52 +16,70 @@ describe('ResizeDetectDiv Component', () => {
   });
 
   it('render with default props does not crash', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <ResizeDetectDivInternal width={100} height={100} className="SOMECLASS">
         Text
       </ResizeDetectDivInternal>
     );
-    expect(wrapper.length).toEqual(1);
-    expect(wrapper.hasClass('SOMECLASS')).toBe(true);
+    const element = container.getElementsByClassName('SOMECLASS');
+    expect(element.length).toBe(1);
   });
+
   it('should call width changed with new width', () => {
-    const wrapper = shallow(
-      <ResizeDetectDivInternal
-        width={100}
-        height={100}
-        onWidthChange={zone.onWidthChange}
-        onHeightChange={zone.onHeightChange}
-        onResize={zone.onResize}
-        className="SOMECLASS"
-      >
-        Text
-      </ResizeDetectDivInternal>
-    );
+    const { rerender } = render(<ResizeDetectDivInternal
+      width={100}
+      height={100}
+      onWidthChange={zone.onWidthChange}
+      onHeightChange={zone.onHeightChange}
+      onResize={zone.onResize}
+      className="SOMECLASS"
+    > Text </ResizeDetectDivInternal>);
     // simulate resize update, this is done by the withResizeDetector wrapper
-    wrapper.setProps({ width: 50 });
+    rerender(<ResizeDetectDivInternal
+      width={50}
+      height={100}
+      onWidthChange={zone.onWidthChange}
+      onHeightChange={zone.onHeightChange}
+      onResize={zone.onResize}
+      className="SOMECLASS"
+    > Text </ResizeDetectDivInternal>)
     expect(spyWidth).toHaveBeenCalledWith(50);
     expect(spyResize).toHaveBeenCalledWith(50, 100);
 
-    wrapper.setProps({ height: 50 });
+    rerender(<ResizeDetectDivInternal
+      width={50}
+      height={50}
+      onWidthChange={zone.onWidthChange}
+      onHeightChange={zone.onHeightChange}
+      onResize={zone.onResize}
+      className="SOMECLASS"
+    > Text </ResizeDetectDivInternal>)
     expect(spyHeight).toHaveBeenCalledWith(50);
     expect(spyResize).toHaveBeenCalledWith(50, 50);
   });
+
   it('should not call on change if no size change', () => {
-    const wrapper = shallow(
-      <ResizeDetectDivInternal
-        width={100}
-        height={100}
-        onWidthChange={zone.onWidthChange}
-        onHeightChange={zone.onHeightChange}
-        onResize={zone.onResize}
-        className="SOMECLASS"
-      >
+    const { rerender } = render(<ResizeDetectDivInternal
+      width={100}
+      height={100}
+      onWidthChange={zone.onWidthChange}
+      onHeightChange={zone.onHeightChange}
+      onResize={zone.onResize}
+      className="SOMECLASS"
+    >
         Text
-      </ResizeDetectDivInternal>
-    );
-    wrapper.setProps({ width: 100, height: 100 });
+    </ResizeDetectDivInternal>);
+    rerender(<ResizeDetectDivInternal
+      width={100}
+      height={100}
+      onWidthChange={zone.onWidthChange}
+      onHeightChange={zone.onHeightChange}
+      onResize={zone.onResize}
+      className="SOMECLASS"
+    > Text </ResizeDetectDivInternal>)
     expect(spyHeight).not.toHaveBeenCalled();
     expect(spyWidth).not.toHaveBeenCalled();
     expect(spyResize).not.toHaveBeenCalled();
   });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3668,15 +3668,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.9.tgz#b6f785caa7ea1fe4414d9df42ee0ab67f23d8a6d"
   integrity sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==
 
-"@types/qs@*":
+"@types/qs@*", "@types/qs@^6.9.5":
   version "6.9.9"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.9.tgz#66f7b26288f6799d279edf13da7ccd40d2fa9197"
   integrity sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg==
-
-"@types/qs@^6.9.5":
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
-  integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
 "@types/range-parser@*":
   version "1.2.6"
@@ -11679,16 +11674,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
-prop-types@^15.8.1:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11973,7 +11959,7 @@ react-is@18.1.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
   integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
-react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
This work has started before but React Testing Library has replaced Enzyme. It tests real interactions instead of simulating away everything.