### PR TITLE
Use SVG Icon instead for Drawer and Modal

### DIFF
--- a/packages/components/src/components/drawer/Drawer.tsx
+++ b/packages/components/src/components/drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
-import Icon from '../icon/FontIcon';
 import { DrawerProps, DrawerContentProps } from './interfaces';
+import { Icons, SvgIcon } from '..';
 
 const prefix = 'tk-drawer';
 const buildClass = (classStr: string) => `${prefix}__${classStr}`;
@@ -76,10 +76,10 @@ export const Drawer: React.FC<DrawerProps> = ({
         onClick={handleContentClick}
       >
         {closeButton && (
-          <Icon
-            iconName="cross"
+          <SvgIcon
             aria-label="close"
             className={clsx(buildClass('close'))}
+            icon={Icons.Cross}
             onClick={onClose}
           />
         )}

--- a/packages/components/src/components/modal/Modal.tsx
+++ b/packages/components/src/components/modal/Modal.tsx
@@ -2,6 +2,28 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { clsx } from 'clsx';
 import { Keys } from '../common/eventUtils';
+import { SvgIcon } from '../icon';
+import { Icons } from '..';
+
+import styled from 'styled-components';
+
+const Button = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: absolute;
+  right: 2rem;
+  top: 2rem;
+  z-index: 200;
+
+  > svg {
+    fill: var(--tk-dialog-cross-color, #7c7f86);
+    :hover {
+      fill: var(--tk-dialog-hover-cross-color, #525760);
+    }
+  }
+`
 
 interface ModalProps extends Omit<React.HTMLProps<HTMLDivElement>, 'size'> {
   size: 'small' | 'medium' | 'large' | 'full-width';
@@ -77,12 +99,15 @@ const Modal: React.FC<ModalProps> = ({
     >
       <div role="dialog" className={sizeClasses} onClick={handleContentClick}>
         {closeButton && (
-          <button
-            type="button"
+          <Button
             aria-label="close"
-            className={buildClass('close')}
             onClick={onClose}
-          />
+            type="button"
+          >
+            <SvgIcon
+              icon={Icons.Cross}
+            />
+          </Button>
         )}
         {children}
       </div>


### PR DESCRIPTION
Ever since Symphony switched to loading the client and extensions over Startpage, the rendering of font icons breaks sometimes. In SFE-RTC we replaced all usage of font icons with SVG icons. This is a remaining case for us where the X in closing the modal can break.

This does not affect only SFE-RTC but will fix things for all extensions using `Modal`.

https://perzoinc.atlassian.net/browse/RTC-14251