### PR TITLE
RTC-14706 - Switch Dropdown icons to be SVGIcons

### DIFF
--- a/packages/components/spec/components/time-picker/TimePicker.spec.tsx
+++ b/packages/components/spec/components/time-picker/TimePicker.spec.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
 import TimePicker from '../../../src/components/time-picker/TimePicker';
 
 import { Keys } from '../../../src/components/common/eventUtils';
-import { Dropdown } from '../../../src';
 import { FIELD } from '../../../src/components/time-picker/utils';
 import {
   render,
@@ -39,24 +38,14 @@ describe('TimePicker Component', () => {
     };
   }
 
-  it('should render with default props', () => {
-    const wrapper = shallow(<TimePicker />);
-    expect(wrapper.length).toEqual(1);
+  it('should render', () => {
+    render(<TimePicker />);
   });
-  it('should properly pass props to Dropdown Component', () => {
-    const props = createTestProps({});
-    const wrapper = shallow(<TimePicker {...props} />);
-    const wrapperPicker = wrapper.find(Dropdown);
-    expect(wrapperPicker.length).toBe(1);
-    expect(wrapperPicker.prop('id')).toBe(props.id);
-    expect(wrapperPicker.prop('label')).toBe(props.label);
-    expect(wrapperPicker.prop('showRequired')).toBe(props.showRequired);
-    expect(wrapperPicker.prop('name')).toBe(props.name);
-    expect(wrapperPicker.prop('placeHolder')).toBe(props.placeholder);
-    expect(wrapperPicker.prop('onCopy')).toBe(props.onCopy);
-    expect(wrapperPicker.prop('onCut')).toBe(props.onCut);
-    expect(wrapperPicker.prop('onDrag')).toBe(props.onDrag);
-  });
+
+  it('should properly pass props to the underlying Dropdown component', () => {
+    render(<TimePicker label="New Label"/>);
+    screen.getByText('New Label');
+  })
 
   it('should trigger onFocus', async () => {
     const props = createTestProps({
@@ -238,9 +227,9 @@ describe('TimePicker Component', () => {
 
   describe('should fallback the default step value', () => {
     test.each([
-      [null, '00:00:00', '00:15:00'], // Default fallback value 15 minutes
-      [0, '00:00:00', '00:10:00'], // Min fallback value 10 minutes
-      [99999, '00:00:00', '12:00:00'], // Max fallback value 12 hours
+      [null, '00:00:00', '12:15:00 AM'], // Default fallback value 15 minutes
+      [0, '00:00:00', '12:10:00 AM'], // Min fallback value 10 minutes
+      [99999, '00:00:00', '12:00:00 PM'], // Max fallback value 12 hours
     ])('when step is %p', (step, min, expected) => {
       jest.spyOn(console, 'error').mockImplementation(() => {
         return;
@@ -249,14 +238,14 @@ describe('TimePicker Component', () => {
         min,
         step,
       });
-      const wrapper = shallow(<TimePicker {...props} />);
+      
+      render(<TimePicker {...props} />);
 
-      const dropDownProps = wrapper.find(Dropdown).props();
-      expect(dropDownProps.options).toBeDefined();
-      expect(dropDownProps.options.length).toBeGreaterThan(1);
-      const secondOption = dropDownProps.options[1];
-      expect(secondOption).toBeDefined();
-      expect(secondOption.value).toBe(expected);
+      const input = screen.getByRole('textbox');
+      userEvent.click(input);
+
+      const options = screen.getAllByRole('option')
+      expect(options[1].textContent).toBe(expected)
     });
   });
 

--- a/packages/components/spec/components/toast/Toast.spec.tsx
+++ b/packages/components/spec/components/toast/Toast.spec.tsx
@@ -3,12 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react'
 import { Toast } from '../../../src/components/toast';
 import expect from 'expect'
+import { TkIcon } from '@symphony-ui/uitoolkit-styles/dist/fonts/tk-icons';
 
 describe('Toast', () => {
 
   let closeIcon: boolean;
   let content: JSX.Element | string;
-  let leftIcon: string;
+  let leftIcon: TkIcon;
   let onClickClose: () => void;
   let placement: {
       horizontal: 'center' | 'left' | 'right';
@@ -70,7 +71,7 @@ describe('Toast', () => {
       show = !show;
     }
 
-    const { container, rerender } = render(
+    const { rerender } = render(
       <Toast
         closeIcon={closeIcon}
         leftIcon={leftIcon}
@@ -82,9 +83,8 @@ describe('Toast', () => {
     );
 
     screen.getByText('Some text')
-
-    const close = container.querySelector('.tk-icon-cross')
-    userEvent.click(close)
+    const element = screen.getByTestId('ICON_CROSS')
+    userEvent.click(element)
 
     rerender(
       <Toast

--- a/packages/components/src/components/dropdown/CustomRender.tsx
+++ b/packages/components/src/components/dropdown/CustomRender.tsx
@@ -4,6 +4,8 @@ import { components } from 'react-select';
 import Icon from '../icon/FontIcon';
 import Loader from '../loader';
 import { SearchHeaderOption } from './interfaces';
+import { SvgIcon } from '../icon';
+import { Icons } from '..';
 
 /**
  * Useful to stop propagating on mouse down events in custom renderers
@@ -120,9 +122,9 @@ export const DropdownIndicator = (props: any) => {
       {...props}
       innerProps={{ 'data-testid': props.selectProps['data-testid'] }}
     >
-      <Icon
+      <SvgIcon
         className="tk-select__single-value"
-        iconName={menuIsOpen ? 'drop-up' : 'drop-down'}
+        icon={menuIsOpen ? Icons.DropUp : Icons.DropDown}
       />
     </components.DropdownIndicator>;
 };

--- a/packages/components/src/components/toast/Toast.tsx
+++ b/packages/components/src/components/toast/Toast.tsx
@@ -4,6 +4,7 @@ import * as PropTypes from 'prop-types';
 import { clsx } from 'clsx';
 import Icon from '../icon/FontIcon';
 import { TkIcon } from  '@symphony-ui/uitoolkit-styles/dist/fonts/tk-icons';
+import { Icons, SvgIcon } from '..';
 
 interface Placement {
     horizontal: 'left' | 'center' | 'right';
@@ -17,8 +18,10 @@ export interface ToastProps extends Omit<React.HTMLProps<HTMLDivElement>, 'child
     closeIcon?: boolean;
     /** Content of the Toast */
     content: string | JSX.Element;
+
     /** If set, icon will be placed to the left */
     leftIcon?: TkIcon;
+    
     /** Function to call on close action */
     onClickClose?: () => void;
     /** Placement of Toast, relative to parent container */
@@ -62,8 +65,9 @@ export const Toast: React.FC<ToastProps> = ({
         iconName={ leftIcon }
       /> }
       { content }
-      { closeIcon && <i
-        className="tk-icon-cross tk-toast__icon-right"
+      { closeIcon && <SvgIcon
+        className="tk-toast__icon-right"
+        icon={Icons.Cross}
         onClick={ onClickClose }
       />}
 

--- a/packages/styles/.circleci/config.yml
+++ b/packages/styles/.circleci/config.yml
@@ -16,7 +16,7 @@ cdn-credentials: &cdn-credentials
 orbs:
   node: circleci/node@5.1.0
   aws-cli: circleci/aws-cli@2.0
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1.4.6
 
 jobs:
   checkout-and-bump: # TODO: Move in a common part

--- a/packages/styles/src/components/atoms/_toast.scss
+++ b/packages/styles/src/components/atoms/_toast.scss
@@ -15,7 +15,7 @@
     }
 
     &__icon-right {
-        color: $scolor-graphite-minus-55;
+        fill: $scolor-graphite-minus-55;
         margin-left: toRem(16);
         &:hover {
             cursor: pointer;

--- a/packages/styles/src/uitoolkit-components/_select.scss
+++ b/packages/styles/src/uitoolkit-components/_select.scss
@@ -122,7 +122,7 @@ body {
           }
         }
         .tk-select__single-value {
-          color: inherit;
+          fill: inherit;
           white-space: nowrap;
         }
       }
@@ -165,7 +165,7 @@ body {
         padding: 0; // override lib styles
         padding-right: var(--tk-select__dropdown-indicator-padding-right);
         .tk-select__single-value {
-          color: getColor($graphite, '50');
+          fill: getColor($graphite, '50');
         }
       }
     }


### PR DESCRIPTION
As previously discussed font icon rendering started breaking at times since Startpage was introduced and the solution has been to switch to SVGIcons which is a more modern way of doing it. This fixes the `Dropdown` component.