### PR TITLE
Was using too modern target in tsconfig

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2017",
     "module": "CommonJS",
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
`2017` is the version used in SFE-Lite and I think the null coalescing or optional chaining is what causes the problem when SFE-Lite tries importing.