### PR TITLE
RTC-14800 Remove styled components for popped out window styles forwarding

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -6,7 +6,7 @@ The React components library of Symphony`s design system
 
 ## Requirements
 
-- Node 12+
+- Node 20+
 - Yarn 1.22+
 
 ## Browser support

--- a/packages/components/docs/getting-started.md
+++ b/packages/components/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Node 10+
+- Node 20+
 - Yarn
 
 ## 🛠 Install

--- a/packages/components/src/components/modal/Modal.tsx
+++ b/packages/components/src/components/modal/Modal.tsx
@@ -5,26 +5,6 @@ import { Keys } from '../common/eventUtils';
 import { SvgIcon } from '../icon';
 import { Icons } from '..';
 
-import styled from 'styled-components';
-
-const Button = styled.button`
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  position: absolute;
-  right: 2rem;
-  top: 2rem;
-  z-index: 200;
-
-  > svg {
-    fill: var(--tk-dialog-cross-color, #7c7f86);
-    :hover {
-      fill: var(--tk-dialog-hover-cross-color, #525760);
-    }
-  }
-`
-
 interface ModalProps extends Omit<React.HTMLProps<HTMLDivElement>, 'size'> {
   size: 'small' | 'medium' | 'large' | 'full-width';
   className?: string;
@@ -99,15 +79,14 @@ const Modal: React.FC<ModalProps> = ({
     >
       <div role="dialog" className={sizeClasses} onClick={handleContentClick}>
         {closeButton && (
-          <Button
+          <button
             aria-label="close"
+            className={clsx(buildClass('close'), className)}
             onClick={onClose}
             type="button"
           >
-            <SvgIcon
-              icon={Icons.Cross}
-            />
-          </Button>
+            <SvgIcon icon={Icons.Cross} />
+          </button>
         )}
         {children}
       </div>

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -4,7 +4,7 @@ The official styles library of Symphony's design system
 
 ## Requirements
 
-- Node 12+
+- Node 20+
 - Yarn 1.22+
 
 ## Browser support
@@ -36,12 +36,12 @@ Automated visual testing uses software to automate the process of comparing visu
 
 [Creevey](https://github.com/wKich/creevey/) is a Cross-browser screenshot testing tool for Storybook with a fancy UI Runner.
 
-**Requirements**  
+**Requirements**
 
  - Selenium Grid
- - [Chromedriver](https://chromedriver.chromium.org/downloads)  
+ - [Chromedriver](https://chromedriver.chromium.org/downloads)
 
-**Setting Up**  
+**Setting Up**
 
  1. Download Selenium Server.
 
@@ -65,14 +65,14 @@ java -jar selenium-server-4.1.1.jar node
 yarn start
 yarn test
 ```
-**Update the test images**  
+**Update the test images**
 
 When the visual testing detects new components or changes on the existing ones it will fail the tests. In order to fix it you will need to run the `update-test-images.sh` script.
-It accepts as a parameter the URL of the CircleCI's `report.zip` file. 
+It accepts as a parameter the URL of the CircleCI's `report.zip` file.
 
 Example:
 
-`$ ./update-test-images.sh https://output.circle-artifacts.com/output/job/54d8d83d-315b-46e3-bcc2-34f1a75d1f9f/artifacts/0/.creevey/report/report.zip` 
+`$ ./update-test-images.sh https://output.circle-artifacts.com/output/job/54d8d83d-315b-46e3-bcc2-34f1a75d1f9f/artifacts/0/.creevey/report/report.zip`
 
 It will execute the following steps automatically:
 

--- a/packages/styles/src/components/atoms/_dialog.scss
+++ b/packages/styles/src/components/atoms/_dialog.scss
@@ -62,35 +62,21 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   }
 
   &__close {
-    position: absolute;
-    top: toRem(32);
-    right: toRem(32);
-    z-index: $z-index-dialog;
-    box-shadow: none;
-    box-sizing: border-box;
-    border: none;
     background: none;
-    display: flex;
-    align-content: center;
-    justify-content: center;
+    border: none;
     cursor: pointer;
-    outline: none;
-    color: $--tk-dialog-cross-color;
     padding: 0;
+    position: absolute;
+    right: 2rem;
+    top: 2rem;
+    z-index: 200;
 
-    &:before {
-      font-family: 'tk-icons';
-      font-size: toRem(14);
-      @include tk-icon-cross;
-    }
+    &>svg {
+      fill: var(--tk-dialog-cross-color, #7c7f86);
 
-    &:hover {
-      color: $--tk-dialog-hover-cross-color;
-    }
-
-    &:focus {
-      @include addOutline();
-      outline-offset: toRem(4);
+      &:hover {
+        fill: var(--tk-dialog-hover-cross-color, #525760);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Component styles are not forwarded when using styled components in popped out windows.

Hopefully, using SASS styles will fix the issue.

## JIRA ticket

https://perzoinc.atlassian.net/browse/RTC-14800

## Demo

Looks the same:
![image](https://github.com/SymphonyPlatformSolutions/symphony-ui-toolkit/assets/112877883/d90fb814-c53a-46c5-a559-a79ebf1507f0)

Hover:
![image](https://github.com/SymphonyPlatformSolutions/symphony-ui-toolkit/assets/112877883/bc87d92b-795d-49b7-86d0-6fccc981d45a)

