### PR TITLE
RTC-14883 - Set minimum required Node version to 14 instead of 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "packageManager": "yarn@1.22.11",
   "engines": {
-    "node": ">=16.14.0"
+    "node": ">=14.21.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,7 @@
     "react-dom": ">=16.8.0"
   },
   "engines": {
-    "node": ">=16.14.0"
+    "node": ">=14.21.2"
   },
   "dependencies": {
     "@popperjs/core": "^2.4.4",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=16.14.0"
+    "node": ">=14.21.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.10.4",


### PR DESCRIPTION
When SFE-Lite imports UI Toolkit, the minimum specified Node engine needs to be met. SFE-Lite runs on 14 and this was set to 16, so lowering in this PR.

The reason it was set to 16 was because in order to run Storybook, 16 is the minimum version required, but SFE-Lite does not run Storybook, it just imports the package.