### PR TITLE
Change display property of button to inline-flex

### DIFF
--- a/packages/styles/src/components/atoms/_button.scss
+++ b/packages/styles/src/components/atoms/_button.scss
@@ -6,7 +6,7 @@
   border: none;
   border-radius: toRem(28);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   letter-spacing: toRem(0.5);
   line-height: toRem(16);


### PR DESCRIPTION
Seems like my changes messed up the Zoom/Teams button.