### PR TITLE
Remove extra semicolon

### DIFF
--- a/packages/components/src/components/tooltip/Tooltip.tsx
+++ b/packages/components/src/components/tooltip/Tooltip.tsx
@@ -108,7 +108,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
       { ...getReferenceProps() }
     >
       { children }
-    </div>;
+    </div>
 
     { /** The tooltip. */ }
     { isOpen && <div


### PR DESCRIPTION
Accidentally added a semicolon in the React render.