### PR TITLE
BYC-1304 Handle focus trap on the Modal component

### DIFF
--- a/packages/components/spec/components/modal/Modal.spec.tsx
+++ b/packages/components/spec/components/modal/Modal.spec.tsx
@@ -140,7 +140,7 @@ describe('Modal', () => {
   describe('should handle focus', () => {
     const component = <div>
       <a href="#">Another element that should not be on focus</a>
-      <Modal focusTrapEnabled size={'small'} show={true}>
+      <Modal size={'small'} show={true}>
         <ModalHeader>Hello, World</ModalHeader>
         <ModalBody>
           <Button variant={'primary'}>Button 1</Button>

--- a/packages/components/spec/components/modal/Modal.spec.tsx
+++ b/packages/components/spec/components/modal/Modal.spec.tsx
@@ -107,32 +107,32 @@ describe('Modal', () => {
     // Modal should be closed
     expect(show).toBeFalsy();
   })
-});
 
-it('should not propagate mouse down event by default', async () => {
-  const onMouseDownParent = jest.fn();
-  const component = <div className="parent" onMouseDown={onMouseDownParent}>
-    <Modal size={'small'} show>
-      <ModalTitle>Title</ModalTitle>
-      <ModalHeader>Header</ModalHeader>
-      <ModalBody>Body</ModalBody>
-    </Modal>
-  </div>;
-  render(component);
-  fireEvent.mouseDown(screen.getByText('Title'))
-  expect(onMouseDownParent).not.toHaveBeenCalled();
-});
+  it('should not propagate mouse down event by default', async () => {
+    const onMouseDownParent = jest.fn();
+    const component = <div className="parent" onMouseDown={onMouseDownParent}>
+      <Modal size={'small'} show>
+        <ModalTitle>Title</ModalTitle>
+        <ModalHeader>Header</ModalHeader>
+        <ModalBody>Body</ModalBody>
+      </Modal>
+    </div>;
+    render(component);
+    fireEvent.mouseDown(screen.getByText('Title'))
+    expect(onMouseDownParent).not.toHaveBeenCalled();
+  });
 
-it('should allow to propagate mouse down event', async () => {
-  const onMouseDownParent = jest.fn();
-  const component = <div className="parent" onMouseDown={onMouseDownParent}>
-    <Modal size={'small'} show onMouseDown={undefined}>
-      <ModalTitle>Title</ModalTitle>
-      <ModalHeader>Header</ModalHeader>
-      <ModalBody>Body</ModalBody>
-    </Modal>
-  </div>;
-  render(component);
-  fireEvent.mouseDown(screen.getByText('Title'))
-  expect(onMouseDownParent).toHaveBeenCalled();
+  it('should allow to propagate mouse down event', async () => {
+    const onMouseDownParent = jest.fn();
+    const component = <div className="parent" onMouseDown={onMouseDownParent}>
+      <Modal size={'small'} show onMouseDown={undefined}>
+        <ModalTitle>Title</ModalTitle>
+        <ModalHeader>Header</ModalHeader>
+        <ModalBody>Body</ModalBody>
+      </Modal>
+    </div>;
+    render(component);
+    fireEvent.mouseDown(screen.getByText('Title'))
+    expect(onMouseDownParent).toHaveBeenCalled();
+  });
 });

--- a/packages/components/spec/components/modal/Modal.spec.tsx
+++ b/packages/components/spec/components/modal/Modal.spec.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Modal, ModalBody, ModalFooter, ModalHeader, ModalTitle } from '../../../src/components';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalTitle } from '../../../src/components';
 import { Keys } from '../../../src/components/common/eventUtils';
 import {
   render,
   screen,
   fireEvent,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 describe('Modal', () => {
   it('should render the content with correct class and without crash', () => {
@@ -135,4 +136,75 @@ describe('Modal', () => {
     fireEvent.mouseDown(screen.getByText('Title'))
     expect(onMouseDownParent).toHaveBeenCalled();
   });
+
+  describe('should handle focus', () => {
+    const component = <div>
+      <a href="#">Another element that should not be on focus</a>
+      <Modal focusTrapEnabled size={'small'} show={true}>
+        <ModalHeader>Hello, World</ModalHeader>
+        <ModalBody>
+          <Button variant={'primary'}>Button 1</Button>
+          <Button variant={'primary'}>Button 2</Button>
+          <Button variant={'primary'}>Button 3</Button>
+        </ModalBody>
+      </Modal>
+    </div>;
+
+    test('by setting the focus on the first element when the modal is opened', async () => {
+      render(component);
+
+      const firstButton = screen.getByText('Button 1');
+
+      // Check if the first focusable element (First Button) is focused
+      expect(firstButton).toHaveFocus()
+    });
+
+    test('by trapping the focus with Tab key', async () => {
+      const { getByText } = render(component);
+
+      const firstButton = getByText('Button 1');
+      const secondButton = getByText('Button 2');
+      const thirdButton = getByText('Button 3');
+
+      expect(firstButton).toHaveFocus()
+
+      // Press Tab key
+      userEvent.tab();
+      expect(secondButton).toHaveFocus();
+
+      // Press Tab key
+      userEvent.tab();
+      expect(thirdButton).toHaveFocus()
+
+      // Press Tab key
+      userEvent.tab();
+
+      // Verify that focus cycles back to the first button
+      expect(firstButton).toHaveFocus()
+    });
+
+    test('by trapping the focus with Shift+Tab key', async () => {
+      const { getByText } = render(component);
+
+      const firstButton = getByText('Button 1');
+      const secondButton = getByText('Button 2');
+      const thirdButton = getByText('Button 3');
+
+      expect(firstButton).toHaveFocus()
+
+      // Press Shift+Tab key
+      userEvent.tab({ shift: true });
+
+      // Verify that focus cycles back to the last button
+      expect(thirdButton).toHaveFocus();
+
+      // Press Shift+Tab key
+      userEvent.tab({ shift: true });
+      expect(secondButton).toHaveFocus()
+
+      // Press Shift+Tab key
+      userEvent.tab({ shift: true });
+      expect(firstButton).toHaveFocus()
+    });
+  })
 });

--- a/packages/components/src/components/modal/Modal.tsx
+++ b/packages/components/src/components/modal/Modal.tsx
@@ -79,7 +79,7 @@ const Modal: React.FC<ModalProps> = ({
   children,
   closeButton,
   onClose,
-  focusTrapEnabled,
+  focusTrapEnabled = true,
   parentNode,
   show,
   ...rest

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -177,29 +177,3 @@ export const ModalWithCloseHandler: Story = {
     );
   }
 };
-
-export const ModalWithFocusTrapped: Story = {
-  render: () => {
-    const [show, setShow] = React.useState(true);
-    const handleClose = () => {
-      setShow(false);
-    };
-    return (
-      <div>
-        <Button onClick={() => setShow(true)}>Open the Modal</Button>
-        <Modal size="medium" closeButton show={show} onClose={handleClose} focusTrapEnabled>
-          <ModalTitle>Medium modal with focus trap</ModalTitle>
-          <ModalBody>{body}</ModalBody>
-          <ModalFooter>
-            <Button variant={'tertiary'} onClick={handleClose}>
-            Cancel
-            </Button>
-            <Button variant={'primary'} onClick={handleClose}>
-            Confirm
-            </Button>
-          </ModalFooter>
-        </Modal>
-      </div>
-    );
-  }
-};

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -177,3 +177,29 @@ export const ModalWithCloseHandler: Story = {
     );
   }
 };
+
+export const ModalWithFocusTrapped: Story = {
+  render: () => {
+    const [show, setShow] = React.useState(true);
+    const handleClose = () => {
+      setShow(false);
+    };
+    return (
+      <div>
+        <Button onClick={() => setShow(true)}>Open the Modal</Button>
+        <Modal size="medium" closeButton show={show} onClose={handleClose} focusTrapEnabled>
+          <ModalTitle>Medium modal with focus trap</ModalTitle>
+          <ModalBody>{body}</ModalBody>
+          <ModalFooter>
+            <Button variant={'tertiary'} onClick={handleClose}>
+            Cancel
+            </Button>
+            <Button variant={'primary'} onClick={handleClose}>
+            Confirm
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </div>
+    );
+  }
+};


### PR DESCRIPTION
## Description

Manage the trap of focusing on the modal component.
The added logic is quite simple, and solves simple scenarios. I'll add complexity later if more complex situations come up.

This behavior is set by default, because this is the default behavior recommended by accessibility guidelines. 
>When a modal element is displayed, focus should be placed in the modal. Focus needs to be "trapped" inside the modal when it is visible, until it is dismissed.
(Source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal)

However, it can be deactivated with `focusTrapEnabled={false}`.

## JIRA ticket

[JIRA_Ticket](https://perzoinc.atlassian.net/browse/BYC-1304)

## Demo

https://github.com/user-attachments/assets/a534b614-9bc6-4f53-990c-505441f273d2

