### PR TITLE
BYC-1470 make nav component accessible

### DIFF
--- a/packages/components/spec/components/nav/Nav.spec.tsx
+++ b/packages/components/spec/components/nav/Nav.spec.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 import { render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { specialChars } from '@testing-library/user-event';
 import * as React from 'react';
 import Nav from '../../../src/components/nav';
 
@@ -36,6 +36,88 @@ describe('Nav component test suite =>', () => {
       await waitFor(() => {
         expect(getByText('banana')).not.toHaveClass('tk-nav-item--active');
         expect(getByText('peach')).toHaveClass('tk-nav-item--active');
+      })
+
+    });
+
+    it('should activate an item on enter', async () => {
+      const { getByText } = render(
+        <Nav items={items} />
+      );
+
+      expect(getByText('banana')).toHaveClass('tk-nav-item--active');
+
+      userEvent.type(getByText('peach'), specialChars.enter);
+      
+
+      await waitFor(() => {
+        expect(getByText('banana')).not.toHaveClass('tk-nav-item--active');
+        expect(getByText('peach')).toHaveClass('tk-nav-item--active');
+      })
+
+    });
+
+    it('should activate an item on space', async () => {
+      const { getByText } = render(
+        <Nav items={items} />
+      );
+
+      expect(getByText('banana')).toHaveClass('tk-nav-item--active');
+
+      userEvent.type(getByText('peach'), specialChars.space);
+      
+
+      await waitFor(() => {
+        expect(getByText('banana')).not.toHaveClass('tk-nav-item--active');
+        expect(getByText('peach')).toHaveClass('tk-nav-item--active');
+      })
+
+    });
+
+    it('should activate item has focus when first tab', async () => {
+      const { getByText } = render(
+        <Nav items={items} />
+      );
+
+      expect(getByText('banana')).toHaveClass('tk-nav-item--active');
+
+      userEvent.tab();
+      
+      await waitFor(() => {
+        expect(getByText('banana')).toHaveFocus();
+      })
+
+    });
+
+    it('should move focus using arrow keys', async () => {
+      const { getByText } = render(
+        <Nav items={items} />
+      );
+
+      expect(getByText('banana')).toHaveClass('tk-nav-item--active');
+
+      userEvent.type(getByText('banana'), specialChars.arrowRight);
+
+      await waitFor(() => {
+        expect(getByText('peach')).toHaveFocus();
+      })
+
+      userEvent.type(getByText('peach'), specialChars.arrowRight);
+
+      await waitFor(() => {
+        expect(getByText('banana')).toHaveFocus();
+      })
+
+      userEvent.type(getByText('banana'), specialChars.arrowLeft);
+
+      await waitFor(() => {
+        expect(getByText('peach')).toHaveFocus();
+      })
+
+      userEvent.type(getByText('peach'), specialChars.arrowLeft);
+
+      await waitFor(() => {
+        expect(getByText('banana')).toHaveFocus();
       })
 
     });

--- a/packages/components/src/components/nav/Nav.tsx
+++ b/packages/components/src/components/nav/Nav.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
+import { Keys } from '../common/eventUtils';
 
 export type NavProps = {
   /** List of items displayed in the navigation bar */
@@ -13,6 +14,7 @@ export type NavProps = {
 export interface NavItem {
   label: string;
   id: number | string;
+  panelId?: number | string;
 
   // Not supported so far keep until supported
   // isDisabled?: boolean;
@@ -23,6 +25,8 @@ export const Nav: React.FC<NavProps> = ({
   activeItemId,
   onActiveTabChange,
 }: NavProps) => {
+
+  const tabs = [];
 
   const [activeNavItemId, setActiveNavItemId] = React.useState(items?.[0]?.id);
 
@@ -39,20 +43,39 @@ export const Nav: React.FC<NavProps> = ({
     }
   }
 
+  const handleKeydown = (key: string) => {
+    const localDocument = tabs[0]?.ownerDocument;
+    const focusedElementIndex = tabs.findIndex(el => el === localDocument?.activeElement);
+
+    if (!localDocument || focusedElementIndex < 0) return;
+
+    switch (key) {
+    case Keys.ARROW_RIGHT:
+      tabs[(focusedElementIndex + 1) % (tabs.length)].focus();
+      break;
+    case Keys.ARROW_LEFT:
+      focusedElementIndex === 0 ? tabs[tabs.length - 1].focus() : tabs[focusedElementIndex - 1].focus();
+      break;
+    }
+  }
+
   return (
-    <div>
-      <nav className="tk-nav">
-        <ul className="tk-nav--tabs">
-          {items.map((item) => (
-            <li
-              key={item.id}
-              onClick={() => handleClick(item)}
-              className={clsx('tk-nav-item', { 'tk-nav-item--active': activeNavItemId === item.id })}>
-              {item.label}
-            </li>
-          ))}
-        </ul>
-      </nav>
+    <div role="tablist" className="tk-nav--tabs">
+      {items.map((item, idx) => (
+        <button
+          role = "tab"
+          ref={ref => {tabs[idx] = ref}}
+          key={item.id}
+          id={'tk-tab-' + item.id}
+          aria-controls={item.panelId && 'tk-panel-' + item.panelId}
+          aria-selected={activeNavItemId === item.id}
+          onClick={() => handleClick(item)}
+          onKeyDown={(evt) => handleKeydown(evt.key)}
+          tabIndex={activeNavItemId === item.id ? 0 : -1}
+          className={clsx('tk-nav-item', { 'tk-nav-item--active': activeNavItemId === item.id })}>
+          {item.label}
+        </button>
+      ))}
     </div>
   )
 };

--- a/packages/components/stories/Nav.stories.tsx
+++ b/packages/components/stories/Nav.stories.tsx
@@ -19,14 +19,17 @@ const navItems: NavItem[] = [
   {
     label: 'Item 0',
     id: 0,
+    panelId: 0
   },
   {
     label: 'Item 1',
     id: 1,
+    panelId: 1
   },
   {
     label: 'Item 2',
     id: 2,
+    panelId: 2
   },
 ];
 
@@ -54,7 +57,7 @@ export const NavigationWithContent: Story = {
           {activeItemId === 0 ? (
             <div>Content item {activeItemId}</div>
           ) : (
-            <div>{activeItemId === 1 ? <div>Content item {activeItemId} </div> : <div>Content item {activeItemId}</div>}</div>
+            <div>{activeItemId === 1 ? <div role="tabpanel" aria-labelledby={'tk-tab-'+activeItemId} id={'tk-panel-'+activeItemId}>Content item {activeItemId} </div> : <div  role="tabpanel" aria-labelledby={'tk-tab-'+activeItemId} id={'tk-panel-'+activeItemId}>Content item {activeItemId}</div>}</div>
           )}
         </div>
       </div>

--- a/packages/styles/src/components/atoms/_nav.scss
+++ b/packages/styles/src/components/atoms/_nav.scss
@@ -1,36 +1,34 @@
-.tk-nav {
-  &--tabs {
-    width: 100%;
-    list-style: none;
-    display: flex;
-    padding-inline-start: 0;
-    margin: 0;
-    font-size: 1em;
+.tk-nav--tabs {
+  width: 100%;
+  list-style: none;
+  display: flex;
+  padding-inline-start: 0;
+  margin: 0;
+  font-size: 1em;
+}
+.tk-nav-item {
+  all: unset;
+  outline: revert;
+  cursor: pointer;
+  text-transform: uppercase;
+  text-decoration: none;
+  background-color: transparent;
+  display: block;
+  margin: 0.5rem 0.75rem;
+  color: $--tk-nav-color-default;
+  border-bottom: toRem(3) solid transparent;
+  &:first-child {
+    margin-left: 0;
   }
-  &-item {
-    all: unset;
-    outline: revert;
-    cursor: pointer;
-    text-transform: uppercase;
-    text-decoration: none;
-    background-color: transparent;
-    display: block;
-    margin: 0.5rem 0.75rem;
-    color: $--tk-nav-color-default;
-    border-bottom: toRem(3) solid transparent;
-    &:first-child {
-      margin-left: 0;
-    }
-    &:last-child {
-      margin-right: 0;
-    }
-    &--active {
-      color: $--tk-nav-color-active;
-      border-bottom-color: $scolor-electricity !important;
-    }
-    &:hover {
-      color: $--tk-nav-color-hover;
-      border-bottom-color: $--tk-nav-color-border-bottom;
-    }
+  &:last-child {
+    margin-right: 0;
+  }
+  &--active {
+    color: $--tk-nav-color-active;
+    border-bottom-color: $scolor-electricity !important;
+  }
+  &:hover {
+    color: $--tk-nav-color-hover;
+    border-bottom-color: $--tk-nav-color-border-bottom;
   }
 }

--- a/packages/styles/src/components/atoms/_nav.scss
+++ b/packages/styles/src/components/atoms/_nav.scss
@@ -1,4 +1,4 @@
-ul.tk-nav {
+.tk-nav {
   &--tabs {
     width: 100%;
     list-style: none;
@@ -7,12 +7,9 @@ ul.tk-nav {
     margin: 0;
     font-size: 1em;
   }
-}
-
-/* This should most probably be moved inside --tabs in order to support later more 
-kinds of nav */
-li.tk-nav {
   &-item {
+    all: unset;
+    outline: revert;
     cursor: pointer;
     text-transform: uppercase;
     text-decoration: none;

--- a/packages/styles/stories/navigation.stories.js
+++ b/packages/styles/stories/navigation.stories.js
@@ -7,13 +7,12 @@ export const Navigation = () =>
 <div class="tk-ml-2">
   <h2>Navs</h2>
   <h3>Default nav</h3>
-  <nav>
-    <ul class="tk-nav--tabs">
-      <li class="tk-nav-item">Item one</li>
-      <li class="tk-nav-item">Item two</li>
-      <li class="tk-nav-item">Item three</li>
-      <li class="tk-nav-item tk-nav-item--active">Active</li>
-    </ul>
-  </nav>
+  <div class="tk-nav--tabs">
+    <button class="tk-nav-item">Item one</button>
+    <button class="tk-nav-item">Item two</button>
+    <div class="tk-nav-item">Item three</div>
+    <button class="tk-nav-item tk-nav-item--active">Active</button>
+    <div class="tk-nav-item tk-nav-item--active">Active</div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Description

Nav was based on a nav, but used as a tablist. I changed it to be now a tablist and to be accessible following tab pattern:
https://www.w3.org/WAI/ARIA/apg/patterns/tabs/

## JIRA ticket

https://perzoinc.atlassian.net/browse/BYC-1470

## Demo


https://github.com/user-attachments/assets/17f6a43b-aa10-4e16-a594-106a267cfb31


