### PR TITLE
C2-24993-uitoolkit: Date picker not accessible

### DIFF
--- a/packages/components/spec/components/date-picker/DatePicker.spec.tsx
+++ b/packages/components/spec/components/date-picker/DatePicker.spec.tsx
@@ -360,7 +360,7 @@ describe('DatePicker Component', () => {
     fireEvent.keyDown(input, { key: Keys.ENTER });
     fireEvent.keyDown(input, { key: 'a' }); // type something that trigger nothing
 
-    const calendar = screen.getByRole('tooltip');
+    const calendar = screen.getByRole('dialog');
     expect(calendar).toBeTruthy();
   });
 

--- a/packages/components/spec/components/date-picker/Header.spec.tsx
+++ b/packages/components/spec/components/date-picker/Header.spec.tsx
@@ -42,6 +42,8 @@ describe('Header Component', () => {
       months: ['J', 'F', 'M', 'A'],
       parentRef: createRef(),
       onChange: jest.fn(),
+      onVisible: jest.fn(),
+      onClose: jest.fn(),
       ...props,
     };
   }
@@ -121,5 +123,47 @@ describe('Header Component', () => {
     wrapper.find('.tk-daypicker-header--prevMonth').simulate('click');
     wrapper.find('.tk-daypicker-header--nextMonth').simulate('click');
     expect(props.onChange).toHaveBeenCalledTimes(4);
+  });
+
+  it('should trigger onVisible when focusing to the button', () => {
+    const divEle = document.createElement('div');
+    divEle.classList.add('focus-visible');
+    const props = createTestProps({});
+    const wrapper = shallow(<Header {...props} />);
+    wrapper.find('.tk-daypicker-header--prevYear').simulate('focus', {
+      nativeEvent: {
+        type: 'focus',
+      },
+      target: divEle
+    });
+    expect(props.onVisible).toHaveBeenCalledTimes(1);
+  });
+
+  it('should focus by programmatically  If the event target has not focus-visible', () => {
+    const divEle = document.createElement('div');
+    const props = createTestProps({});
+    const wrapper = shallow(<Header {...props} />);
+    wrapper.find('.tk-daypicker-header--prevYear').simulate('focus', {
+      nativeEvent: {
+        type: 'focus',
+      },
+      target: divEle
+    });
+    expect(props.onVisible).not.toBeCalled();
+  });
+
+  it('should trigger onClose when losing the focus', () => {
+    const divEle = document.createElement('div');
+    divEle.classList.add('focus-visible');
+    const props = createTestProps({});
+    const wrapper = shallow(<Header {...props} />);
+    wrapper.find('.tk-daypicker-header--prevYear').simulate('focus', {
+      nativeEvent: {
+        type: 'focus',
+      },
+      target: divEle
+    });
+    wrapper.find('.tk-daypicker-header--prevYear').simulate('blur');
+    expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/components/src/components/date-picker/DatePicker.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.tsx
@@ -50,13 +50,14 @@ type DatePickerComponentProps = {
   /** Handle focus event */
   onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   /** Handle calendar open event */
-  onCalendarOpen?: () => void;
+  onCalendarOpen?: (datePickerID: string) => void;
   /** Handle calendar close event */
-  onCalendarClose?: () => void;
+  onCalendarClose?: (datePickerID: string) => void;
   placeholder?: string;
   locale?: string;
   placement?: 'top' | 'bottom' | 'right' | 'left';
   todayButton?: string;
+  ariaLabel?: string;
   /* The picker is open on render (not supported with menuPortalTarget) */
   showOverlay?: boolean;
   showRequired?: boolean;
@@ -189,10 +190,10 @@ class DatePicker extends Component<
   componentDidUpdate(prevProps, prevState) {
     if (this.state.showPicker && !prevState.showPicker) {
       this.mountDayPickerInstance();
-      this.props.onCalendarOpen && this.props.onCalendarOpen();
+      this.props.onCalendarOpen && this.props.onCalendarOpen(this.props.id);
     } else if (!this.state.showPicker && prevState.showPicker) {
       this.unmountDayPickerInstance();
-      this.props.onCalendarClose && this.props.onCalendarClose();
+      this.props.onCalendarClose && this.props.onCalendarClose(this.props.id);
       if(this.props.shouldResetInvalidDate) {
         const validDate = this.props.date && this.props.date;
         this.setState({
@@ -492,6 +493,7 @@ class DatePicker extends Component<
       label,
       labels,
       todayButton,
+      ariaLabel,
       menuPortalTarget,
       menuPortalStyles,
     } = this.props;
@@ -500,7 +502,9 @@ class DatePicker extends Component<
 
     return (
       <div
-        role="tooltip"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
         ref={this.setPopperElement}
         className="DatePickerContainer"
         style={{

--- a/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
+++ b/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
@@ -60,6 +60,8 @@ type DayPickerComponentProps = {
 type DayPickerComponentState = {
   today: Date;
   currentMonth: Date;
+  showTooltip: boolean;
+  currentID: string;
 };
 
 const DAYS_SELECTOR = '.tk-daypicker-day--outside, .tk-daypicker-day';
@@ -78,6 +80,8 @@ class DayPicker extends React.Component<
     this.state = {
       today: startOfToday(),
       currentMonth: props.month || props.selectedDays || new Date(),
+      showTooltip: false,
+      currentID: ''
     };
 
     this.handleKeyDownContainer = this.handleKeyDownContainer.bind(this);
@@ -446,7 +450,7 @@ class DayPicker extends React.Component<
 
   render() {
     const { dir, labels, locale } = this.props;
-    const { currentMonth } = this.state;
+    const { currentMonth, showTooltip, currentID } = this.state;
 
     const now = new Date();
     return (
@@ -459,7 +463,11 @@ class DayPicker extends React.Component<
           date={currentMonth}
           dir={dir}
           months={getMonths(now, locale)}
+          showTooltip={showTooltip}
+          currentID={currentID}
           onChange={(month) => this.setState({ currentMonth: month })}
+          onVisible={(id) => this.setState({showTooltip: true, currentID: id})}
+          onClose={() => this.setState({showTooltip: false, currentID: ''})}
           labels={labels}
           parentRef={this.dayPicker}
         />

--- a/packages/styles/src/uitoolkit-components/_date-picker.scss
+++ b/packages/styles/src/uitoolkit-components/_date-picker.scss
@@ -43,6 +43,14 @@
       font-size: toRem(12);
       line-height: toRem(16);
     }
+    &--cusTomTooltip {
+      transform: translate(-15px, -15px) !important;
+    }
+    &--button {
+      &:focus-visible {
+        @include outlineStyle;
+      }
+    }
   }
 
   .tk-daypicker-weekday {
@@ -118,6 +126,10 @@
         visibility: hidden;
       }
     }
+    
+    .focus-visible {
+      @include outlineStyle;
+    }
   }
 
   .tk-daypicker-footer {
@@ -130,6 +142,9 @@
       text-transform: uppercase;
       font-size: toRem(12);
       line-height: toRem(16);
+      &:focus-visible {
+        @include outlineStyle;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
- Add tooltip for preYear, preMonth, nextYear, nextMonth button
- When calendar popped-up, focus is moving to the current date
- SR is announcing that filed has calendar pop-up

## JIRA ticket
[C2-24993](https://perzoinc.atlassian.net/browse/C2-24993)

## Demo
![Screenshot (16)](https://github.com/user-attachments/assets/a8b81af4-270d-4f30-a0fd-50c9564215ef)


Put screenshots, videos or gif demos of what is the behaviour after your PR.


[C2-24993]: https://perzoinc.atlassian.net/browse/C2-24993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ