### PR TITLE
[CES-20069] Add aria-label in dropdown

### DIFF
--- a/packages/components/src/components/dropdown/CustomRender.tsx
+++ b/packages/components/src/components/dropdown/CustomRender.tsx
@@ -70,6 +70,7 @@ export const Input = (props: any) => {
     onDrag={props?.selectProps?.onDrag}
     onKeyUp={props?.selectProps?.onKeyUp}
     isHidden={inputAlwaysDisplayed ? !inputAlwaysDisplayed : false}
+    aria-label={props?.selectProps?.label}
     type="search"
   />;
 }

--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -263,6 +263,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           }}
           defaultValue={defaultValue}
           id={id}
+          label={label}
           name={name}
           className={clsx(prefix, { [`${prefix}--${variant}`]: variant }, { [`${prefix}--${size}`]: size })}
           closeMenuOnSelect={closeMenuOnSelect}


### PR DESCRIPTION
## Description

Add aria-label in dropdown as htmlFor in react labels link the label with the dropdown input

## JIRA ticket

[CES-20069](https://perzoinc.atlassian.net/browse/CES-20069)

## Demo

<img width="810" alt="image" src="https://github.com/user-attachments/assets/b37bcfd1-b5db-477a-8a15-af05c689a950" />

---

https://github.com/user-attachments/assets/279d49b7-c65c-4cee-96dc-c12f21f674dd




[CES-20069]: https://perzoinc.atlassian.net/browse/CES-20069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ