### PR TITLE
[CES-20338][Accessibility] Add outline color + change size of the close modal button on dialog component

### DIFF
--- a/packages/styles/src/components/atoms/_dialog.scss
+++ b/packages/styles/src/components/atoms/_dialog.scss
@@ -70,12 +70,17 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
     right: 2rem;
     top: 2rem;
     z-index: 200;
+    height: toRem(24);
+    width: toRem(24);
 
     &>svg {
       fill: var(--tk-dialog-cross-color, #7c7f86);
 
       &:hover {
         fill: var(--tk-dialog-hover-cross-color, #525760);
+      }
+      &:focus {
+        outline-color: getColor($electricity, '40');
       }
     }
   }


### PR DESCRIPTION
## Description
For accessibility, update of the outline color + change of the size of the focus on close modal button for the dialog component. 

## JIRA ticket

[CES-20338](https://perzoinc.atlassian.net/browse/CES-20338)

## Demo
<img width="524" alt="Screenshot 2025-03-17 at 22 17 33" src="https://github.com/user-attachments/assets/c3f03c50-8e5f-4b83-ad9d-4f5e9944eee9" />

