### PR TITLE
fix bug break DatePicker

### DIFF
--- a/packages/components/spec/components/date-picker/DatePicker.spec.tsx
+++ b/packages/components/spec/components/date-picker/DatePicker.spec.tsx
@@ -208,8 +208,7 @@ describe('DatePicker Component', () => {
       const currentDate = new Date().getDate();
       const props = createTestProps({ showOverlay: true, date: null });
       render(<DatePicker {...props} />);
-      const icon = document.querySelector('.tk-icon-calendar');
-      fireEvent.keyDown(icon, { key: Keys.ENTER });
+      fireEvent.click(screen.getByRole('textbox'));
 
       const focusedCell = screen.getByText(`${currentDate}`);
       expect(document.activeElement).toEqual(focusedCell);
@@ -217,11 +216,20 @@ describe('DatePicker Component', () => {
     it('should focus to selected date if the value is not null', () => {
       const props = createTestProps({ showOverlay: true });
       render(<DatePicker {...props} />);
-      const icon = document.querySelector('.tk-icon-calendar');
-      fireEvent.keyDown(icon, { key: Keys.ENTER });
+      fireEvent.click(screen.getByRole('textbox'));
 
       const focusedCell = screen.getByText(`${props.date.getDate()}`);
       expect(document.activeElement).toEqual(focusedCell);
+    });
+    it('should not break Date Picker if the date was deselected and reopen Date Picker', async () => {
+      const props = createTestProps({ showOverlay: true });
+      render(<DatePicker {...props} />);
+
+      // Deselected date
+      fireEvent.click(screen.getByRole('textbox'));
+      fireEvent.click(screen.getByText(`${props.date.getDate()}`));
+      fireEvent.click(screen.getByRole('textbox'));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
     it('should trigger onCalendarOpen', () => {
       const props = createTestProps({});

--- a/packages/components/spec/components/date-picker/DatePicker.spec.tsx
+++ b/packages/components/spec/components/date-picker/DatePicker.spec.tsx
@@ -221,7 +221,7 @@ describe('DatePicker Component', () => {
       const focusedCell = screen.getByText(`${props.date.getDate()}`);
       expect(document.activeElement).toEqual(focusedCell);
     });
-    it('should not break Date Picker if the date was deselected and reopen Date Picker', async () => {
+    it('should show Date Picker if the selected date was deselected and reopen Date Picker', async () => {
       const props = createTestProps({ showOverlay: true });
       render(<DatePicker {...props} />);
 

--- a/packages/components/src/components/date-picker/DatePicker.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.tsx
@@ -374,6 +374,8 @@ class DatePicker extends Component<
         DAYS_VISIBLE_SELECTOR
       );
       const dateNode = dayNodes[selectedDate - 1];
+      // Only focus to current date or selected date
+      // In case all the dates displayed on DatePicker do not have tab-index = 0 then do not focus on it
       if (dateNode && dateNode.tabIndex === 0) {
         dateNode.focus();
       }

--- a/packages/components/src/components/date-picker/DatePicker.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.tsx
@@ -368,12 +368,15 @@ class DatePicker extends Component<
   }
 
   private handleFocusToSelectedDate() {
-    const selectedDate = this.state.navigationDate.getDate();
+    const selectedDate = this.state.navigationDate ? this.state.navigationDate.getDate() : new Date().getDate();
     if (this.refPicker && this.refPicker.dayPicker) {
       const dayNodes = this.refPicker.dayPicker.querySelectorAll(
         DAYS_VISIBLE_SELECTOR
       );
-      dayNodes[selectedDate - 1].focus();
+      const dateNode = dayNodes[selectedDate - 1];
+      if (dateNode && dateNode.tabIndex === 0) {
+        dateNode.focus();
+      }
     }
   }
 


### PR DESCRIPTION
## Description
### BUG 1:
#### Steps to reproduce:
- Open calendar picker
- Select any date and deselect after
- Open calendar picker again -> **Crash Date picker**

https://github.com/user-attachments/assets/6e514847-8fe2-4683-b85f-ab096453f62f

### BUG 2
#### Steps to reproduce:
- Open date picker dialog
- Select “today”
- Re-open the date picker and press the “next/left arrow” key or click on the previous/next month button
- Close the date picker and reopen it -> **Highlight focus moved to the wrong date**

https://github.com/user-attachments/assets/6c6455f3-d5d4-42e6-a13f-26a6e5ee4f00

## FIX
- add more condition to check when selecting and deselecting the date that did not crash the date picker and the focus will be on the current date.
- update focus to ensure the correct date will be focused when opening the date picker.

https://github.com/user-attachments/assets/6d3174aa-8477-4668-86cf-0cf340d15768
