### PR TITLE
Revert "C2-24526-uitoolkit-fixbug: fix issue about SR read incorrect row and column when focusing to date in DatePicker, delete heading role of the button in header and fix the other issues"

### DIFF
--- a/packages/components/spec/components/date-picker/DatePicker.spec.tsx
+++ b/packages/components/spec/components/date-picker/DatePicker.spec.tsx
@@ -87,6 +87,16 @@ describe('DatePicker Component', () => {
     wrapper.setProps({ locale: 'ja' });
     expect(spy).toHaveBeenCalled();
   });
+  it('should update value of input when date props change to empty', () => {
+    const spy = jest.spyOn(DatePicker.prototype, 'componentDidUpdate');
+    const props = createTestProps({});
+    const wrapper = shallow(<DatePicker {...props} />);
+    expect(spy).toHaveBeenCalledTimes(0);
+    wrapper.setProps({ date: undefined });
+    wrapper.update();
+    expect(spy).toHaveBeenCalled();
+    expect(wrapper.state('inputValue')).toBe(null);
+  });
   it('Should update date when it changes to a valid value and changes date props value', () => {
     const props = createTestProps({ shouldResetInvalidDate: true });
     const wrapper = shallow(<DatePicker {...props} />);

--- a/packages/components/src/components/date-picker/DatePicker.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.tsx
@@ -224,6 +224,13 @@ class DatePicker extends Component<
           : null,
       });
     }
+    // update dynamically if date change
+    if (this.props.date !== prevProps.date && !this.props.date) {
+      this.setState({
+        navigationDate: new Date(),
+        inputValue: null,
+      });
+    }
   }
 
   /**

--- a/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
+++ b/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
@@ -176,10 +176,10 @@ class DayPicker extends React.Component<
     const action = isBefore(date, nextDate) ? 'next' : 'previous';
     if (delta !== 0) {
       this.setState({ currentMonth: nextDate }, () =>
-        this.focusOnlyEnabledCell(nextDate, action, getDaysInMonth(this.state.currentMonth), false)
+        this.focusOnlyEnabledCell(nextDate, action, null, false)
       );
     } else {
-      this.focusOnlyEnabledCell(nextDate, action, getDaysInMonth(this.state.currentMonth));
+      this.focusOnlyEnabledCell(nextDate, action, null);
     }
   }
 
@@ -308,41 +308,23 @@ class DayPicker extends React.Component<
   // Create WeekDayHeader
   renderSubHeader(weekdaysShort, weekdaysLong, dir) {
     return (
-      <div role="rowgroup"> 
-        <div
-          className="tk-daypicker-weekday"
-          role="row"
-          style={{ direction: dir }}
-        >
-          {weekdaysShort.map((day, index) => (
-            <div
-              className="tk-daypicker-weekday--text"
-              role="columnheader"
-              key={index}
-              title={weekdaysLong[index]}
-            >
-              {day}
-            </div>
-          ))}
-        </div>
+      <div
+        className="tk-daypicker-weekday"
+        role="row"
+        style={{ direction: dir }}
+      >
+        {weekdaysShort.map((day, index) => (
+          <div
+            className="tk-daypicker-weekday--text"
+            role="columnheader"
+            key={index}
+            title={weekdaysLong[index]}
+          >
+            {day}
+          </div>
+        ))}
       </div>
     );
-  }
-
-  renderRemainingRows(days: number[], daysNeededForNextMonth: number) {
-    const rowsArray: React.ReactElement[] = [];
-    for (let i = 0; i < days.length; i += 7) {
-      // Take once every 7 days.
-      const dayOfWeek = days.slice(i, i + 7);
-      const isLastRow = i + 7 > days.length;
-      rowsArray.push(
-        <div role="row" className="tk-daypicker-row">
-          {this.renderInsideDay(dayOfWeek)}
-          {isLastRow && this.renderOutsideDay(daysNeededForNextMonth)}
-        </div>
-      )
-    }
-    return rowsArray;
   }
 
   renderOutsideDay(days: number): JSX.Element[] {
@@ -353,83 +335,7 @@ class DayPicker extends React.Component<
           aria-selected="false"
           className="tk-daypicker-day--outside"
           tabIndex={-1}
-          role="gridcell"
         />
-      );
-    });
-  }
-
-  renderInsideDay(days: number[]): JSX.Element[] {
-    const {
-      locale,
-      selectedDays,
-      disabledDays,
-      highlightedDays,
-      onDayClick,
-    } = this.props;
-    const { today, currentMonth } = this.state;
-    const selectedDateString = selectedDays
-      ? lightFormat(selectedDays, 'yyyy-MM-dd')
-      : null;
-    const todayDateString = lightFormat(today, 'yyyy-MM-dd');
-
-    const isSelectedDayVisible =
-      selectedDays &&
-      differenceInCalendarMonths(selectedDays, currentMonth) === 0;
-
-    return days.map((cell) => {
-      const cellDate = setDate(currentMonth, cell);
-      const cellName = formatDay(cellDate, locale);
-
-      const itemDateString = lightFormat(cellDate, 'yyyy-MM-dd');
-      const isSelected = itemDateString === selectedDateString;
-      const isToday = itemDateString === todayDateString;
-      const isDisabled = matchDay(cellDate, disabledDays);
-      const isHighlighted = matchDay(cellDate, highlightedDays);
-      const ariaSelected = isDisabled ? undefined : isSelected;
-      const isTabIndex = isSelectedDayVisible
-        ? isSelected
-          ? 0
-          : -1
-        : isToday
-          ? 0
-          : -1; // focus on selected day otherwise current day
-      return (
-        <button
-          key={cellName}
-          className={clsx(
-            'tk-daypicker-day',
-            {
-              'tk-daypicker-day--selected': isSelected,
-            },
-            {
-              'tk-daypicker-day--today': isToday,
-            },
-            {
-              'tk-daypicker-day--highlighted': isHighlighted && !isDisabled,
-            },
-            { 'tk-daypicker-day--disabled': isDisabled }
-          )}
-          role="gridcell"
-          type="button"
-          aria-label={cellName}
-          aria-selected={ariaSelected}
-          tabIndex={isTabIndex}
-          onKeyDown={(e) =>
-            this.handleKeyDownCell(e, cellDate, {
-              disabled: isDisabled,
-              selected: isSelected,
-            })
-          }
-          onClick={() =>
-            onDayClick(cellDate, {
-              disabled: isDisabled,
-              selected: isSelected,
-            })
-          }
-        >
-          {cell}
-        </button>
       );
     });
   }
@@ -438,32 +344,92 @@ class DayPicker extends React.Component<
     const {
       dir,
       locale,
+      selectedDays,
+      disabledDays,
+      highlightedDays,
+      onDayClick,
     } = this.props;
-    const { currentMonth } = this.state;
+    const { today, currentMonth } = this.state;
     const daysInMonth = getDaysInMonth(currentMonth);
     const daysNeededForLastMonth = getDaysNeededForLastMonth(
       currentMonth,
       locale
     );
-    const nbOfDaysNeedForFirstRow = 7 - daysNeededForLastMonth;
-    const daysNeedForFirstRow = Array.from({ length: nbOfDaysNeedForFirstRow }, (_, i) => i + 1);
-    const nbOfRemainingDays = daysInMonth - nbOfDaysNeedForFirstRow;
-    const remainingDays =  Array.from({ length: nbOfRemainingDays }, (_, i) => i + 1 + nbOfDaysNeedForFirstRow);
     const daysNeededForNextMonth = getDaysNeededForNextMonth(
       currentMonth,
       locale
     );
 
-    return (
-      <div className="tk-daypicker-body" role="rowgroup" style={{ direction: dir }}>
-        {/* Render the first row */}
-        <div role="row" className="tk-daypicker-row">
-          {this.renderOutsideDay(daysNeededForLastMonth)}
-          {this.renderInsideDay(daysNeedForFirstRow)}
-        </div>
+    const selectedDateString = selectedDays
+      ? lightFormat(selectedDays, 'yyyy-MM-dd')
+      : null;
+    const todayDateString = lightFormat(today, 'yyyy-MM-dd');
 
-        {/* Render the remaining row */}
-        {this.renderRemainingRows(remainingDays, daysNeededForNextMonth)}
+    const isSelectedDayVisible =
+      selectedDays &&
+      differenceInCalendarMonths(selectedDays, currentMonth) === 0;
+    return (
+      <div className="tk-daypicker-body" role="grid" style={{ direction: dir }}>
+        {this.renderOutsideDay(daysNeededForLastMonth)}
+
+        {toArray(daysInMonth).map((cell) => {
+          const cellNumber = cell + 1;
+          const cellDate = setDate(currentMonth, cellNumber);
+          const cellName = formatDay(cellDate, locale);
+
+          const itemDateString = lightFormat(cellDate, 'yyyy-MM-dd');
+          const isSelected = itemDateString === selectedDateString;
+          const isToday = itemDateString === todayDateString;
+          const isDisabled = matchDay(cellDate, disabledDays);
+          const isHighlighted = matchDay(cellDate, highlightedDays);
+          const ariaSelected = isDisabled ? undefined : isSelected;
+          const isTabIndex = isSelectedDayVisible
+            ? isSelected
+              ? 0
+              : -1
+            : isToday
+              ? 0
+              : -1; // focus on selected day otherwise current day
+
+          return (
+            <button
+              key={cellName}
+              className={clsx(
+                'tk-daypicker-day',
+                {
+                  'tk-daypicker-day--selected': isSelected,
+                },
+                {
+                  'tk-daypicker-day--today': isToday,
+                },
+                {
+                  'tk-daypicker-day--highlighted': isHighlighted && !isDisabled,
+                },
+                { 'tk-daypicker-day--disabled': isDisabled }
+              )}
+              role="gridcell"
+              type="button"
+              aria-label={cellName}
+              aria-selected={ariaSelected}
+              tabIndex={isTabIndex}
+              onKeyDown={(e) =>
+                this.handleKeyDownCell(e, cellDate, {
+                  disabled: isDisabled,
+                  selected: isSelected,
+                })
+              }
+              onClick={() =>
+                onDayClick(cellDate, {
+                  disabled: isDisabled,
+                  selected: isSelected,
+                })
+              }
+            >
+              {cellNumber}
+            </button>
+          );
+        })}
+        {this.renderOutsideDay(daysNeededForNextMonth)}
       </div>
     );
   }
@@ -511,15 +477,13 @@ class DayPicker extends React.Component<
           labels={labels}
           parentRef={this.dayPicker}
         />
-        <div role="grid">
-          {this.renderSubHeader(
-            getWeekdaysShort(now, locale),
-            getWeekdaysLong(now, locale),
-            dir
-          )}
-          {this.renderBody()}
-          {this.renderFooter()}
-        </div>
+        {this.renderSubHeader(
+          getWeekdaysShort(now, locale),
+          getWeekdaysLong(now, locale),
+          dir
+        )}
+        {this.renderBody()}
+        {this.renderFooter()}
       </div>
     );
   }

--- a/packages/components/src/components/date-picker/sub-component/Header.tsx
+++ b/packages/components/src/components/date-picker/sub-component/Header.tsx
@@ -117,6 +117,7 @@ const Header: FunctionComponent<HeaderProps> = ({
   return (
     <div
       className="tk-daypicker-header"
+      role="heading"
       style={{ direction: dir }}
     >
       <div>

--- a/packages/components/src/components/date-picker/utils/dateUtils.tsx
+++ b/packages/components/src/components/date-picker/utils/dateUtils.tsx
@@ -138,14 +138,7 @@ export function getSiblingOrCurrent(elem, selector: string, direction: 'nextElem
   let index = 0;
   while (sibling && index < (maxStepToCheck || Number.MAX_SAFE_INTEGER)) {
     if (sibling.matches(selector)) return sibling;
-    if (sibling[direction]) {
-      sibling = sibling[direction];
-    } else {
-      const parentSibling = sibling.parentElement[direction];
-      if (parentSibling) {
-        sibling = direction === 'nextElementSibling' ? parentSibling.firstElementChild : parentSibling.lastElementChild;
-      }
-    }
+    sibling = sibling[direction];
     index++;
   }
 }

--- a/packages/styles/src/uitoolkit-components/_date-picker.scss
+++ b/packages/styles/src/uitoolkit-components/_date-picker.scss
@@ -79,10 +79,6 @@
       toRem(32) toRem(32) toRem(32);
     font-size: toRem(14);
 
-    .tk-daypicker-row {
-      display: contents;
-    }
-
     .tk-daypicker-day {
       display: flex;
       align-items: center;
@@ -118,14 +114,9 @@
         &:hover {
           outline: none;
         }
-        &:focus {
-          outline: none;
-        }
       }
       &--outside {
-        border: none;
-        background: none;
-        pointer-events: none;
+        visibility: hidden;
       }
 
       &--today {


### PR DESCRIPTION
Reverts SymphonyPlatformSolutions/symphony-ui-toolkit#686

A regression was introduced with the [PR](SymphonyPlatformSolutions/symphony-ui-toolkit#686). See example on this [PR](https://github.com/SymphonyPlatformSolutions/symphony-ui-toolkit/pull/692).

So, this PR reverts the change.