### PR TITLE
fix regression bug: C2-25521, C2-25526, C2-25779, C2-25789, C2-25819

### DIFF
--- a/packages/components/spec/components/date-picker/DatePicker.spec.tsx
+++ b/packages/components/spec/components/date-picker/DatePicker.spec.tsx
@@ -87,16 +87,6 @@ describe('DatePicker Component', () => {
     wrapper.setProps({ locale: 'ja' });
     expect(spy).toHaveBeenCalled();
   });
-  it('should update value of input when date props change to empty', () => {
-    const spy = jest.spyOn(DatePicker.prototype, 'componentDidUpdate');
-    const props = createTestProps({});
-    const wrapper = shallow(<DatePicker {...props} />);
-    expect(spy).toHaveBeenCalledTimes(0);
-    wrapper.setProps({ date: undefined });
-    wrapper.update();
-    expect(spy).toHaveBeenCalled();
-    expect(wrapper.state('inputValue')).toBe(null);
-  });
   it('Should update date when it changes to a valid value and changes date props value', () => {
     const props = createTestProps({ shouldResetInvalidDate: true });
     const wrapper = shallow(<DatePicker {...props} />);
@@ -232,6 +222,18 @@ describe('DatePicker Component', () => {
 
       const focusedCell = screen.getByText(`${props.date.getDate()}`);
       expect(document.activeElement).toEqual(focusedCell);
+    });
+    it('should show Date Picker if the selected date was deselected and reopen Date Picker', async () => {
+      const props = createTestProps({ showOverlay: true });
+      render(<DatePicker {...props} />);
+      const icon = document.querySelector('.tk-icon-calendar');
+      fireEvent.keyDown(icon, { key: Keys.ENTER });
+
+      // Deselected date
+      fireEvent.click(screen.getByText(`${props.date.getDate()}`));
+      // Reopen Date picker
+      fireEvent.keyDown(icon, { key: Keys.ENTER });
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
     it('should trigger onCalendarOpen', () => {
       const props = createTestProps({});

--- a/packages/components/src/components/date-picker/DatePicker.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.tsx
@@ -224,13 +224,6 @@ class DatePicker extends Component<
           : null,
       });
     }
-    // update dynamically if date change
-    if (this.props.date !== prevProps.date && !this.props.date) {
-      this.setState({
-        navigationDate: new Date(),
-        inputValue: null,
-      });
-    }
   }
 
   /**
@@ -375,12 +368,16 @@ class DatePicker extends Component<
   }
 
   private handleFocusToSelectedDate() {
-    const selectedDate = this.state.navigationDate.getDate();
+    const selectedDate = this.state.navigationDate ? this.state.navigationDate.getDate() : new Date().getDate();
     if (this.refPicker && this.refPicker.dayPicker) {
       const dayNodes = this.refPicker.dayPicker.querySelectorAll(
         DAYS_VISIBLE_SELECTOR
       );
-      dayNodes[selectedDate - 1].focus();
+      const dateNode = dayNodes[selectedDate - 1];
+      if (dateNode.tabIndex === 0) {
+        // Only focus to current date or selected date when opening the date picker
+        dateNode?.focus();
+      }
     }
   }
 

--- a/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
+++ b/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
@@ -392,7 +392,7 @@ class DayPicker extends React.Component<
               : -1; // focus on selected day otherwise current day
 
           return (
-            <button
+            <div
               key={cellName}
               className={clsx(
                 'tk-daypicker-day',
@@ -408,7 +408,6 @@ class DayPicker extends React.Component<
                 { 'tk-daypicker-day--disabled': isDisabled }
               )}
               role="gridcell"
-              type="button"
               aria-label={cellName}
               aria-selected={ariaSelected}
               tabIndex={isTabIndex}
@@ -426,7 +425,7 @@ class DayPicker extends React.Component<
               }
             >
               {cellNumber}
-            </button>
+            </div>
           );
         })}
         {this.renderOutsideDay(daysNeededForNextMonth)}

--- a/packages/styles/src/uitoolkit-components/_date-picker.scss
+++ b/packages/styles/src/uitoolkit-components/_date-picker.scss
@@ -114,6 +114,9 @@
         &:hover {
           outline: none;
         }
+        &:focus {
+          outline: none;
+        }
       }
       &--outside {
         visibility: hidden;


### PR DESCRIPTION
## Description
[C2-25521](https://perzoinc.atlassian.net/browse/C2-25521), [C2-25526](https://perzoinc.atlassian.net/browse/C2-25526) and  [C2-25789](https://perzoinc.atlassian.net/browse/C2-25789) are the same root cause that is when entering an error value it automatically resets to an empty value => **fix: remove code that allow to update dynamically if date change**

[C2-25779](https://perzoinc.atlassian.net/browse/C2-25779) related to CSS => **fix: add atribute to hide when clicking outside date**

[C2-25819](https://perzoinc.atlassian.net/browse/C2-25819) related to focused date when opening the date picker => **fix: add condition to focus only current date or selected date when opening the date picker**

## Demo
Provided video demo from PR in Lite
