### PR TITLE
fix issue about SR read incorrect row and column when focusing to date in DatePicker

### DIFF
--- a/packages/components/src/components/date-picker/DatePicker.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.tsx
@@ -451,6 +451,8 @@ class DatePicker extends Component<
         );
         if (elCell) {
           elCell.focus();
+        } else {
+          this.refPicker.dayPicker.querySelector('.tk-daypicker-today')?.focus();
         }
       }
       break;

--- a/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
+++ b/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
@@ -46,7 +46,6 @@ import {
   startOfToday,
   startOfWeek,
   startOfMonth,
-  isBefore,
 } from 'date-fns';
 
 type DayPickerComponentProps = {
@@ -171,16 +170,14 @@ class DayPicker extends React.Component<
     );
   }
 
-  arrowNavigation(date: Date, nextDate: Date) {
+  arrowNavigation(date: Date, nextDate: Date, action: 'next' | 'previous') {
     const delta = differenceInCalendarMonths(nextDate, date);
-    const action = isBefore(date, nextDate) ? 'next' : 'previous';
-    const maxStepCheck = getDaysInMonth(this.state.currentMonth);
     if (delta !== 0) {
       this.setState({ currentMonth: nextDate }, () =>
-        this.focusOnlyEnabledCell(nextDate, action, maxStepCheck, false)
+        this.focusOnlyEnabledCell(nextDate, action,null, false)
       );
     } else {
-      this.focusOnlyEnabledCell(nextDate, action, maxStepCheck);
+      this.focusOnlyEnabledCell(nextDate, action, null);
     }
   }
 
@@ -265,16 +262,16 @@ class DayPicker extends React.Component<
       this.focusOnlyEnabledCell(nextCell, 'previous', MAX_STEP_TO_CHECK);
       break;
     case Keys.ARROW_LEFT:
-      this.arrowNavigation(date, addDays(date, -1 * direction));
+      this.arrowNavigation(date, addDays(date, -1 * direction), 'previous');
       break;
     case Keys.ARROW_UP:
-      this.arrowNavigation(date, addDays(date, -7));
+      this.arrowNavigation(date, addDays(date, -7), 'previous');
       break;
     case Keys.ARROW_RIGHT:
-      this.arrowNavigation(date, addDays(date, 1 * direction));
+      this.arrowNavigation(date, addDays(date, 1 * direction), 'next');
       break;
     case Keys.ARROW_DOWN:
-      this.arrowNavigation(date, addDays(date, 7));
+      this.arrowNavigation(date, addDays(date, 7), 'next');
       break;
     default:
       break;

--- a/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
+++ b/packages/components/src/components/date-picker/sub-component/DayPicker.tsx
@@ -174,12 +174,13 @@ class DayPicker extends React.Component<
   arrowNavigation(date: Date, nextDate: Date) {
     const delta = differenceInCalendarMonths(nextDate, date);
     const action = isBefore(date, nextDate) ? 'next' : 'previous';
+    const maxStepCheck = getDaysInMonth(this.state.currentMonth);
     if (delta !== 0) {
       this.setState({ currentMonth: nextDate }, () =>
-        this.focusOnlyEnabledCell(nextDate, action, null, false)
+        this.focusOnlyEnabledCell(nextDate, action, maxStepCheck, false)
       );
     } else {
-      this.focusOnlyEnabledCell(nextDate, action, null);
+      this.focusOnlyEnabledCell(nextDate, action, maxStepCheck);
     }
   }
 
@@ -308,23 +309,41 @@ class DayPicker extends React.Component<
   // Create WeekDayHeader
   renderSubHeader(weekdaysShort, weekdaysLong, dir) {
     return (
-      <div
-        className="tk-daypicker-weekday"
-        role="row"
-        style={{ direction: dir }}
-      >
-        {weekdaysShort.map((day, index) => (
-          <div
-            className="tk-daypicker-weekday--text"
-            role="columnheader"
-            key={index}
-            title={weekdaysLong[index]}
-          >
-            {day}
-          </div>
-        ))}
+      <div role="rowgroup"> 
+        <div
+          className="tk-daypicker-weekday"
+          role="row"
+          style={{ direction: dir }}
+        >
+          {weekdaysShort.map((day, index) => (
+            <div
+              className="tk-daypicker-weekday--text"
+              role="columnheader"
+              key={index}
+              title={weekdaysLong[index]}
+            >
+              {day}
+            </div>
+          ))}
+        </div>
       </div>
     );
+  }
+
+  renderRemainingRows(days: number[], daysNeededForNextMonth: number) {
+    const rowsArray: React.ReactElement[] = [];
+    for (let i = 0; i < days.length; i += 7) {
+      // Take once every 7 days.
+      const dayOfWeek = days.slice(i, i + 7);
+      const isLastRow = i + 7 > days.length;
+      rowsArray.push(
+        <div role="row" className="tk-daypicker-row">
+          {this.renderInsideDay(dayOfWeek)}
+          {isLastRow && this.renderOutsideDay(daysNeededForNextMonth)}
+        </div>
+      )
+    }
+    return rowsArray;
   }
 
   renderOutsideDay(days: number): JSX.Element[] {
@@ -335,14 +354,14 @@ class DayPicker extends React.Component<
           aria-selected="false"
           className="tk-daypicker-day--outside"
           tabIndex={-1}
+          role="gridcell"
         />
       );
     });
   }
 
-  renderBody() {
+  renderInsideDay(days: number[]): JSX.Element[] {
     const {
-      dir,
       locale,
       selectedDays,
       disabledDays,
@@ -350,16 +369,6 @@ class DayPicker extends React.Component<
       onDayClick,
     } = this.props;
     const { today, currentMonth } = this.state;
-    const daysInMonth = getDaysInMonth(currentMonth);
-    const daysNeededForLastMonth = getDaysNeededForLastMonth(
-      currentMonth,
-      locale
-    );
-    const daysNeededForNextMonth = getDaysNeededForNextMonth(
-      currentMonth,
-      locale
-    );
-
     const selectedDateString = selectedDays
       ? lightFormat(selectedDays, 'yyyy-MM-dd')
       : null;
@@ -368,67 +377,93 @@ class DayPicker extends React.Component<
     const isSelectedDayVisible =
       selectedDays &&
       differenceInCalendarMonths(selectedDays, currentMonth) === 0;
+
+    return days.map((cell) => {
+      const cellDate = setDate(currentMonth, cell);
+      const cellName = formatDay(cellDate, locale);
+
+      const itemDateString = lightFormat(cellDate, 'yyyy-MM-dd');
+      const isSelected = itemDateString === selectedDateString;
+      const isToday = itemDateString === todayDateString;
+      const isDisabled = matchDay(cellDate, disabledDays);
+      const isHighlighted = matchDay(cellDate, highlightedDays);
+      const ariaSelected = isDisabled ? undefined : isSelected;
+      const isTabIndex = isSelectedDayVisible
+        ? isSelected
+          ? 0
+          : -1
+        : isToday
+          ? 0
+          : -1; // focus on selected day otherwise current day
+      return (
+        <div
+          key={cellName}
+          className={clsx(
+            'tk-daypicker-day',
+            {
+              'tk-daypicker-day--selected': isSelected,
+            },
+            {
+              'tk-daypicker-day--today': isToday,
+            },
+            {
+              'tk-daypicker-day--highlighted': isHighlighted && !isDisabled,
+            },
+            { 'tk-daypicker-day--disabled': isDisabled }
+          )}
+          role="gridcell"
+          aria-label={cellName}
+          aria-selected={ariaSelected}
+          tabIndex={isTabIndex}
+          onKeyDown={(e) =>
+            this.handleKeyDownCell(e, cellDate, {
+              disabled: isDisabled,
+              selected: isSelected,
+            })
+          }
+          onClick={() =>
+            onDayClick(cellDate, {
+              disabled: isDisabled,
+              selected: isSelected,
+            })
+          }
+        >
+          {cell}
+        </div>
+      );
+    });
+  }
+
+  renderBody() {
+    const {
+      dir,
+      locale,
+    } = this.props;
+    const { currentMonth } = this.state;
+    const daysInMonth = getDaysInMonth(currentMonth);
+    const daysNeededForLastMonth = getDaysNeededForLastMonth(
+      currentMonth,
+      locale
+    );
+    const nbOfDaysNeedForFirstRow = 7 - daysNeededForLastMonth;
+    const daysNeedForFirstRow = Array.from({ length: nbOfDaysNeedForFirstRow }, (_, i) => i + 1);
+    const nbOfRemainingDays = daysInMonth - nbOfDaysNeedForFirstRow;
+    const remainingDays =  Array.from({ length: nbOfRemainingDays }, (_, i) => i + 1 + nbOfDaysNeedForFirstRow);
+    const daysNeededForNextMonth = getDaysNeededForNextMonth(
+      currentMonth,
+      locale
+    );
+
     return (
-      <div className="tk-daypicker-body" role="grid" style={{ direction: dir }}>
-        {this.renderOutsideDay(daysNeededForLastMonth)}
+      <div className="tk-daypicker-body" role="rowgroup" style={{ direction: dir }}>
+        {/* Render the first row */}
+        <div role="row" className="tk-daypicker-row">
+          {this.renderOutsideDay(daysNeededForLastMonth)}
+          {this.renderInsideDay(daysNeedForFirstRow)}
+        </div>
 
-        {toArray(daysInMonth).map((cell) => {
-          const cellNumber = cell + 1;
-          const cellDate = setDate(currentMonth, cellNumber);
-          const cellName = formatDay(cellDate, locale);
-
-          const itemDateString = lightFormat(cellDate, 'yyyy-MM-dd');
-          const isSelected = itemDateString === selectedDateString;
-          const isToday = itemDateString === todayDateString;
-          const isDisabled = matchDay(cellDate, disabledDays);
-          const isHighlighted = matchDay(cellDate, highlightedDays);
-          const ariaSelected = isDisabled ? undefined : isSelected;
-          const isTabIndex = isSelectedDayVisible
-            ? isSelected
-              ? 0
-              : -1
-            : isToday
-              ? 0
-              : -1; // focus on selected day otherwise current day
-
-          return (
-            <div
-              key={cellName}
-              className={clsx(
-                'tk-daypicker-day',
-                {
-                  'tk-daypicker-day--selected': isSelected,
-                },
-                {
-                  'tk-daypicker-day--today': isToday,
-                },
-                {
-                  'tk-daypicker-day--highlighted': isHighlighted && !isDisabled,
-                },
-                { 'tk-daypicker-day--disabled': isDisabled }
-              )}
-              role="gridcell"
-              aria-label={cellName}
-              aria-selected={ariaSelected}
-              tabIndex={isTabIndex}
-              onKeyDown={(e) =>
-                this.handleKeyDownCell(e, cellDate, {
-                  disabled: isDisabled,
-                  selected: isSelected,
-                })
-              }
-              onClick={() =>
-                onDayClick(cellDate, {
-                  disabled: isDisabled,
-                  selected: isSelected,
-                })
-              }
-            >
-              {cellNumber}
-            </div>
-          );
-        })}
-        {this.renderOutsideDay(daysNeededForNextMonth)}
+        {/* Render the remaining row */}
+        {this.renderRemainingRows(remainingDays, daysNeededForNextMonth)}
       </div>
     );
   }
@@ -476,13 +511,15 @@ class DayPicker extends React.Component<
           labels={labels}
           parentRef={this.dayPicker}
         />
-        {this.renderSubHeader(
-          getWeekdaysShort(now, locale),
-          getWeekdaysLong(now, locale),
-          dir
-        )}
-        {this.renderBody()}
-        {this.renderFooter()}
+        <div role="grid">
+          {this.renderSubHeader(
+            getWeekdaysShort(now, locale),
+            getWeekdaysLong(now, locale),
+            dir
+          )}
+          {this.renderBody()}
+          {this.renderFooter()}
+        </div>
       </div>
     );
   }

--- a/packages/components/src/components/date-picker/sub-component/Header.tsx
+++ b/packages/components/src/components/date-picker/sub-component/Header.tsx
@@ -132,7 +132,6 @@ const Header: FunctionComponent<HeaderProps> = ({
   return (
     <div
       className="tk-daypicker-header"
-      role="heading"
       style={{ direction: dir }}
     >
       <div>

--- a/packages/components/src/components/date-picker/utils/dateUtils.tsx
+++ b/packages/components/src/components/date-picker/utils/dateUtils.tsx
@@ -142,9 +142,10 @@ export function getSiblingOrCurrent(elem, selector: string, direction: 'nextElem
       sibling = sibling[direction];
     } else {
       const parentSibling = sibling.parentElement[direction];
-      if (parentSibling) {
-        sibling = direction === 'nextElementSibling' ? parentSibling.firstElementChild : parentSibling.lastElementChild;
+      if (!parentSibling) {
+        return;
       }
+      sibling = direction === 'nextElementSibling' ? parentSibling.firstElementChild : parentSibling.lastElementChild;
     }
     index++;
   }

--- a/packages/components/src/components/date-picker/utils/dateUtils.tsx
+++ b/packages/components/src/components/date-picker/utils/dateUtils.tsx
@@ -138,7 +138,14 @@ export function getSiblingOrCurrent(elem, selector: string, direction: 'nextElem
   let index = 0;
   while (sibling && index < (maxStepToCheck || Number.MAX_SAFE_INTEGER)) {
     if (sibling.matches(selector)) return sibling;
-    sibling = sibling[direction];
+    if (sibling[direction]) {
+      sibling = sibling[direction];
+    } else {
+      const parentSibling = sibling.parentElement[direction];
+      if (parentSibling) {
+        sibling = direction === 'nextElementSibling' ? parentSibling.firstElementChild : parentSibling.lastElementChild;
+      }
+    }
     index++;
   }
 }

--- a/packages/styles/src/uitoolkit-components/_date-picker.scss
+++ b/packages/styles/src/uitoolkit-components/_date-picker.scss
@@ -93,6 +93,7 @@
       border-radius: toRem(2);
       font-weight: 400;
       background: none;
+      margin: 2px;
       &:hover {
         @include outlineStyle;
       }

--- a/packages/styles/src/uitoolkit-components/_date-picker.scss
+++ b/packages/styles/src/uitoolkit-components/_date-picker.scss
@@ -79,6 +79,10 @@
       toRem(32) toRem(32) toRem(32);
     font-size: toRem(14);
 
+    .tk-daypicker-row {
+      display: contents;
+    }
+
     .tk-daypicker-day {
       display: flex;
       align-items: center;
@@ -119,7 +123,9 @@
         }
       }
       &--outside {
-        visibility: hidden;
+        border: none;
+        background: none;
+        pointer-events: none;
       }
 
       &--today {


### PR DESCRIPTION
## Description
Restructure the html tree so that the days of the month are rendered correctly with the corresponding row and coloumn.

## JIRA ticket
[C2-24526](https://perzoinc.atlassian.net/browse/C2-24526)

## Demo
### BEFORE
![image](https://github.com/user-attachments/assets/2e85017c-3e22-477e-aa05-eae5c2e8cf37)

### AFTER
![image](https://github.com/user-attachments/assets/ea02b18d-3b80-4044-bc10-4784c30b903e)



[C2-24526]: https://perzoinc.atlassian.net/browse/C2-24526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ