### PR TITLE
RTC-15444 - Replace shortid with nanoid

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,11 +45,11 @@
     "date-fns": "^2.16.1",
     "emoji-js": "^3.5.0",
     "github-markdown-css": "^4.0.0",
+    "nanoid": "^5.1.5",
     "prop-types": "^15.8.1",
     "react-resize-detector": "^5.0.3",
     "react-select": "^4.3.1",
-    "react-virtualized": "^9.22.2",
-    "shortid": "^2.2.16"
+    "react-virtualized": "^9.22.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/components/src/components/input/InputDecorator.tsx
+++ b/packages/components/src/components/input/InputDecorator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { useMemo } from 'react';
 import { clsx } from 'clsx';
-import shortid from 'shortid';
+import { nanoid } from 'nanoid';
 import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecorator';
 import {
   LabelTooltipDecoratorProps,
@@ -63,10 +63,10 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
 
   // Generate unique ID if not provided
   const inputId = useMemo(() => {
-    return child?.props?.id || `tk-input-${shortid.generate()}`;
+    return child?.props?.id || `tk-input-${nanoid()}`;
   }, [child]);
 
-  const tooltipId = useMemo(() => `tk-hint-${shortid.generate()}`, []);
+  const tooltipId = useMemo(() => `tk-hint-${nanoid()}`, []);
 
   const disabled = useMemo(() => {
     return child?.props?.disabled;

--- a/packages/components/src/components/input/TextComponent.tsx
+++ b/packages/components/src/components/input/TextComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { useEffect, useMemo } from 'react';
 import { clsx } from 'clsx';
-import shortid from 'shortid';
+import { nanoid } from 'nanoid';
 
 import { HasValidationProps } from '../validation/interfaces';
 import { HasTooltipProps } from '../tooltip/interfaces';
@@ -125,10 +125,10 @@ const TextComponent: React.FC<
 
     // Generate unique ID if not provided
     const inputId = useMemo(() => {
-      return id || `${prefix}-${shortid.generate()}`;
+      return id || `${prefix}-${nanoid()}`;
     }, [id]);
 
-    const tooltipId = useMemo(() => `tk-hint-${shortid.generate()}`, []);
+    const tooltipId = useMemo(() => `tk-hint-${nanoid()}`, []);
 
     let TagName;
     if (type == Types.TEXTAREA) {

--- a/packages/components/src/components/selection/SelectionInput.tsx
+++ b/packages/components/src/components/selection/SelectionInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { clsx } from 'clsx';
-import shortid from 'shortid';
+import { nanoid } from 'nanoid';
 import SelectionTypes, { SelectionInputTypes } from './SelectionTypes';
 import SelectionStatus, { getCheckedValue } from './SelectionStatus';
 import LabelPlacements from './LabelPlacements';
@@ -48,7 +48,7 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
 }) => {
   // Generate unique ID if not provided
   const memoizedId = useMemo(() => {
-    return id || `${type}-${shortid.generate()}`;
+    return id || `${type}-${nanoid()}`;
   }, [id]);
 
   // Default labelPlacement on right if not provided

--- a/packages/components/src/core/hoc/StylesInjection.tsx
+++ b/packages/components/src/core/hoc/StylesInjection.tsx
@@ -1,26 +1,22 @@
 import * as React from 'react';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
+import { customAlphabet } from 'nanoid';
+
+// @emotion/cache only accepts lowercase alpha characters.
+const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz');
 
 interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
   injectionPoint?: HTMLElement | undefined;
 }
 
 export const StylesInjection = (props: Props) => {
-
-  // @emotion/cache only accept alpha characters
-  // Don't use shortid because it doesn't support less than 64 unique characters (See https://github.com/dylang/shortid#shortidcharactersstring)
-  // Later we will use nanoid
-  const uniqueAlphaCharacterId = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10);
-
   const emotionCache = createCache({
-    key: uniqueAlphaCharacterId,
+    key: nanoid(),
     container: props.injectionPoint
   });
 
-  return (
-    <CacheProvider value={emotionCache} >
-      {props.children}
-    </CacheProvider>
-  )
+  return <CacheProvider value={emotionCache} >
+    {props.children}
+  </CacheProvider>
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10538,11 +10538,6 @@ nanoid@3.1.25:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
 nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
@@ -12702,13 +12697,6 @@ shelljs@^0.8.4:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-shortid@^2.2.16:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
-  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
-  dependencies:
-    nanoid "^2.1.0"
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-15444

`shortid` is deprecated and `nanoid` is preferred. Changing this as we're implementing full Snyk scanning in SFE-RTC and this comes up as a security vulnerability.