### PR TITLE
Replace `nanoid` by `uuid`

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,11 +45,11 @@
     "date-fns": "^2.16.1",
     "emoji-js": "^3.5.0",
     "github-markdown-css": "^4.0.0",
-    "nanoid": "^5.1.5",
     "prop-types": "^15.8.1",
     "react-resize-detector": "^5.0.3",
     "react-select": "^4.3.1",
-    "react-virtualized": "^9.22.2"
+    "react-virtualized": "^9.22.2",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/components/src/components/input/InputDecorator.tsx
+++ b/packages/components/src/components/input/InputDecorator.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
-import { useMemo } from 'react';
 import { clsx } from 'clsx';
-import { nanoid } from 'nanoid';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { callParentAndChildMethod } from '../../utils';
 import LabelTooltipDecorator from '../label-tooltip-decorator/LabelTooltipDecorator';
 import {
   LabelTooltipDecoratorProps,
   LabelTooltipDecoratorPropTypes,
 } from '../label-tooltip-decorator/interfaces';
 import { HasValidationProps } from '../validation/interfaces';
-import { callParentAndChildMethod } from '../../utils';
 
 const RightDecoratorsPropTypes = {
   rightDecorators: PropTypes.oneOfType([
@@ -63,10 +63,10 @@ const InputDecorator: React.FC<InputDecoratorProps> = ({
 
   // Generate unique ID if not provided
   const inputId = useMemo(() => {
-    return child?.props?.id || `tk-input-${nanoid()}`;
+    return child?.props?.id || `tk-input-${uuidv4()}`;
   }, [child]);
 
-  const tooltipId = useMemo(() => `tk-hint-${nanoid()}`, []);
+  const tooltipId = useMemo(() => `tk-hint-${uuidv4()}`, []);
 
   const disabled = useMemo(() => {
     return child?.props?.disabled;

--- a/packages/components/src/components/input/TextComponent.tsx
+++ b/packages/components/src/components/input/TextComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { useEffect, useMemo } from 'react';
 import { clsx } from 'clsx';
-import { nanoid } from 'nanoid';
+import { v4 as uuidv4 } from 'uuid';
 
 import { HasValidationProps } from '../validation/interfaces';
 import { HasTooltipProps } from '../tooltip/interfaces';
@@ -125,10 +125,10 @@ const TextComponent: React.FC<
 
     // Generate unique ID if not provided
     const inputId = useMemo(() => {
-      return id || `${prefix}-${nanoid()}`;
+      return id || `${prefix}-${uuidv4()}`;
     }, [id]);
 
-    const tooltipId = useMemo(() => `tk-hint-${nanoid()}`, []);
+    const tooltipId = useMemo(() => `tk-hint-${uuidv4()}`, []);
 
     let TagName;
     if (type == Types.TEXTAREA) {

--- a/packages/components/src/components/selection/SelectionInput.tsx
+++ b/packages/components/src/components/selection/SelectionInput.tsx
@@ -1,13 +1,13 @@
+import { clsx } from 'clsx';
+import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import * as PropTypes from 'prop-types';
-import { clsx } from 'clsx';
-import { nanoid } from 'nanoid';
-import SelectionTypes, { SelectionInputTypes } from './SelectionTypes';
-import SelectionStatus, { getCheckedValue } from './SelectionStatus';
-import LabelPlacements from './LabelPlacements';
+import { v4 as uuidv4 } from 'uuid';
 import { Keys } from '../common/eventUtils';
 import { HasValidationProps } from '../validation/interfaces';
+import LabelPlacements from './LabelPlacements';
+import SelectionStatus, { getCheckedValue } from './SelectionStatus';
+import SelectionTypes, { SelectionInputTypes } from './SelectionTypes';
 
 interface SelectionInputProps {
   id?: string;
@@ -48,7 +48,7 @@ const SelectionInput: React.FC<SelectionInputPropsWithType> = ({
 }) => {
   // Generate unique ID if not provided
   const memoizedId = useMemo(() => {
-    return id || `${type}-${nanoid()}`;
+    return id || `${type}-${uuidv4()}`;
   }, [id]);
 
   // Default labelPlacement on right if not provided

--- a/packages/components/src/core/hoc/StylesInjection.tsx
+++ b/packages/components/src/core/hoc/StylesInjection.tsx
@@ -1,10 +1,28 @@
-import * as React from 'react';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-import { customAlphabet } from 'nanoid';
+import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
-// @emotion/cache only accepts lowercase alpha characters.
-const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz');
+/**
+ * Generates a UUID-like string using only alphabetic characters
+ * @param alphabet - The alphabet to use for generating the string (default: lowercase a-z)
+ * @returns A string containing only characters from the provided alphabet
+ * @description Converts a standard UUID into an alphabetic string by mapping bytes to alphabet indices
+ */
+const uuidAlpha = (alphabet = 'abcdefghijklmnopqrstuvwxyz') => {
+  let alpha = '';
+  const base = alphabet.length;
+
+  for (let j = 0; j < 5; j++) { // repeat 5 times to get a final id with 20 chars (5 * 4)
+    const bytes = Buffer.from(uuidv4(), 'hex');
+    for (let i = 0; i < bytes.length; i++) {
+      const byte = bytes[i];
+      alpha += alphabet[byte % base];
+    }
+  }
+
+  return alpha;
+};
 
 interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
   injectionPoint?: HTMLElement | undefined;
@@ -12,11 +30,9 @@ interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
 
 export const StylesInjection = (props: Props) => {
   const emotionCache = createCache({
-    key: nanoid(),
-    container: props.injectionPoint
+    key: uuidAlpha(),
+    container: props.injectionPoint,
   });
 
-  return <CacheProvider value={emotionCache} >
-    {props.children}
-  </CacheProvider>
+  return <CacheProvider value={emotionCache}>{props.children}</CacheProvider>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10156,11 +10156,6 @@ nanoid@^3.3.8:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
-nanoid@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.5.tgz#f7597f9d9054eb4da9548cdd53ca70f1790e87de"
-  integrity sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -12520,7 +12515,16 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12626,7 +12630,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12639,6 +12643,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13529,6 +13540,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 uuid@^3.1.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -13865,7 +13881,7 @@ workerpool@6.1.5:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
   integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13878,6 +13894,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
**Replace `nanoid` by `uuid`**

`nanoid` is causing unit test failures in projects using ui-toolkit.

- remove `nanoid` dependency
- add `uuid` dependency (no snyk issue)
- replace `nanoid()` by `uuidv4()`
- replace `customAlphabet()` by a custom function using `uuidv4()`