### PR TITLE
Add id to dropdown input helper

### DIFF
--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -367,7 +367,7 @@ export class Dropdown<T = LabelValue> extends React.Component<
           tooltipCloseLabel={tooltipCloseLabel}
           showRequired={showRequired}
         />
-        {helperText && <div className="tk-input__helper">{helperText}</div>}
+        {helperText && <div id={`${id}-input__helper`} className="tk-input__helper">{helperText}</div>}
       </div>
     );
   }


### PR DESCRIPTION
## Description

The aim of this change is to add an id to dropdown input helper in order to later use it to improve accessibility. The id will be use through aria-describedby when necessary.

## JIRA ticket

[CES-22010](https://perzoinc.atlassian.net/browse/CES-22010)

