### PR TITLE
RTC-15488 - Set plugins array to empty so it doesn't include unnecessary prefixer

### DIFF
--- a/packages/components/src/core/hoc/StylesInjection.tsx
+++ b/packages/components/src/core/hoc/StylesInjection.tsx
@@ -30,8 +30,9 @@ interface Props extends Pick<React.HTMLProps<HTMLDivElement>, 'children'> {
 
 export const StylesInjection = (props: Props) => {
   const emotionCache = createCache({
-    key: uuidAlpha(),
     container: props.injectionPoint,
+    key: uuidAlpha(),
+    stylisPlugins: [],
   });
 
   return <CacheProvider value={emotionCache}>{props.children}</CacheProvider>;


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-15488

See - https://emotion.sh/docs/@emotion/cache#stylisplugins. I think the default `prefixer` is unnecessary and when I'm doing some CSS work it adds a lot of noise inspecting elements as each property is triplicated.