### PR TITLE
UPL-151: `DateTime` component

### DIFF
--- a/packages/components/spec/components/date-time/DateTime.spec.tsx
+++ b/packages/components/spec/components/date-time/DateTime.spec.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DateTime } from '../../../src/components';
+import { DateTimeFormat } from '../../../src/components/date-time/interfaces';
+
+describe('DateTime', () => {
+  const testDate = new Date(2024, 11, 30, 17, 30, 15);
+  const locale = 'en-US';
+
+  const defaultProps = {
+    date: testDate,
+    locale,
+  };
+
+  describe('date', () => {
+    it('should handle Date objects', () => {
+      const { container } = render(<DateTime {...defaultProps} />);
+      expect(container).toHaveTextContent('12/30/2024 05:30 PM');
+    });
+
+    it('should handle ISO string dates', () => {
+      const dateISOString = testDate.toISOString();
+      const { container } = render(
+        <DateTime {...defaultProps} date={dateISOString} />
+      );
+      expect(container).toHaveTextContent('12/30/2024 05:30 PM');
+    });
+  });
+
+  describe('format', () => {
+    it('should display date and time by default', () => {
+      const { container } = render(<DateTime {...defaultProps} />);
+      expect(container).toHaveTextContent('12/30/2024 05:30 PM');
+    });
+
+    it('should display date only', () => {
+      const { container } = render(
+        <DateTime {...defaultProps} format={DateTimeFormat.DATE} />
+      );
+      expect(container).toHaveTextContent('12/30/2024');
+    });
+
+    it('should display time only', () => {
+      const { container } = render(
+        <DateTime {...defaultProps} format={DateTimeFormat.TIME} />
+      );
+      expect(container).toHaveTextContent('05:30 PM');
+    });
+
+    it('should display time with seconds', () => {
+      const { container } = render(
+        <DateTime {...defaultProps} format={DateTimeFormat.TIME_SECS} />
+      );
+      expect(container).toHaveTextContent('05:30:15 PM');
+    });
+  });
+
+  describe('locale', () => {
+    it('should format date according to locale', () => {
+      const { container } = render(
+        <DateTime {...defaultProps} locale="fr-FR" />
+      );
+      expect(container).toHaveTextContent('30/12/2024 17:30');
+    });
+
+    it('should use browser locale when not specified', () => {
+      const { container } = render(<DateTime date={testDate} />);
+      expect(container.textContent).toBeTruthy();
+    });
+  });
+
+  describe('dateFormat', () => {
+    it('should use custom date format when provided', () => {
+      const { container } = render(
+        <DateTime
+          {...defaultProps}
+          format={DateTimeFormat.DATE}
+          dateFormat="yyyy.MM.dd"
+        />
+      );
+      expect(container).toHaveTextContent('2024.12.30');
+    });
+  });
+
+  describe('timeFormat', () => {
+    it('should use custom time format when provided', () => {
+      const { container } = render(
+        <DateTime
+          {...defaultProps}
+          format={DateTimeFormat.TIME}
+          timeFormat="HH:mm"
+        />
+      );
+      expect(container).toHaveTextContent('17:30');
+    });
+  });
+
+  describe('show12HourTime', () => {
+    it('should display time in 24-hour format when show12HourTime is false', () => {
+      const { container } = render(
+        <DateTime
+          {...defaultProps}
+          format={DateTimeFormat.TIME}
+          show12HourTime={false}
+        />
+      );
+      expect(container).toHaveTextContent('17:30');
+    });
+
+    it('should display time in 12-hour format when show12HourTime is true', () => {
+      const { container } = render(
+        <DateTime
+          {...defaultProps}
+          format={DateTimeFormat.TIME}
+          show12HourTime={true}
+        />
+      );
+      expect(container).toHaveTextContent('05:30 PM');
+    });
+  });
+});

--- a/packages/components/src/components/date-time/DateTime.tsx
+++ b/packages/components/src/components/date-time/DateTime.tsx
@@ -1,0 +1,48 @@
+import { format as fnsFormat } from 'date-fns';
+import * as React from 'react';
+import { DateTimeFormat, DateTimeProps } from './interfaces';
+import { DEFAULT_DATE_TIME_FORMAT, DEFAULT_DATE_TIME_FORMATS } from './utils';
+
+/**
+ * Component displaying a date or time (or both) according to the given options.
+ * By default, the component displays the date and time using the user's browser locale.
+ */
+export const DateTime: React.FC<DateTimeProps> = (props) => {
+  const { date, format, locale, dateFormat, timeFormat, show12HourTime } =
+    props;
+  const dateObject: Date = date instanceof Date ? date : new Date(date);
+  const effectiveFormat: DateTimeFormat = format ?? DEFAULT_DATE_TIME_FORMAT;
+
+  // render 2 components for DATE_TIME format
+  if (effectiveFormat === DateTimeFormat.DATE_TIME) {
+    return (
+      <>
+        <DateTime {...props} format={DateTimeFormat.DATE} />{' '}
+        <DateTime {...props} format={DateTimeFormat.TIME} />
+      </>
+    );
+  }
+
+  let formattedDate: string;
+  if (dateFormat && effectiveFormat === DateTimeFormat.DATE) {
+    // apply date format if provided
+    formattedDate = fnsFormat(dateObject, dateFormat);
+  } else if (
+    timeFormat &&
+    [DateTimeFormat.TIME, DateTimeFormat.TIME_SECS].includes(effectiveFormat)
+  ) {
+    // apply time format if provided
+    formattedDate = fnsFormat(dateObject, timeFormat);
+  } else {
+    // apply the default format for the given locale (browser locale by default)
+    const { toStringFn, options } = DEFAULT_DATE_TIME_FORMATS[effectiveFormat];
+    const effectiveOptions = { ...options, hour12: show12HourTime };
+    formattedDate = dateObject[toStringFn](locale, effectiveOptions);
+  }
+
+  return <>{formattedDate}</>;
+};
+
+DateTime.defaultProps = {
+  format: DEFAULT_DATE_TIME_FORMAT,
+};

--- a/packages/components/src/components/date-time/index.ts
+++ b/packages/components/src/components/date-time/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './DateTime';

--- a/packages/components/src/components/date-time/interfaces.ts
+++ b/packages/components/src/components/date-time/interfaces.ts
@@ -1,0 +1,37 @@
+export interface DateTimeProps {
+  /** The date to convert to user locale date (string dates must be provided in ISO format) */
+  date: Date | string;
+  /** The format to use for the date. Available formats are: DATE_TIME (default), DATE, TIME, TIME_SECS */
+  format?: DateTimeFormat;
+  /** The locale to use for the date and time formatting (i.e. 'en-US', 'fr-FR', etc.). Default is the browser locale. */
+  locale?: string;
+  /** Whether to display the time in 12-hour format (i.e. '10:29 AM') or 24-hour format (i.e. 10:29). Default is undefined, relying on the locale formatting. */
+  show12HourTime?: boolean;
+  /** The format to use for the date (i.e. 'yyyy/MM/dd'). If not provided, the locale date format will be used. */
+  dateFormat?: string;
+  /**
+   * The format to use for the time (i.e. 'hh:mm:ss a'). If not provided, the locale time format will be used.
+   * Caution: this format overrides the display of time seconds and 12-hour time.
+   */
+  timeFormat?: string;
+}
+
+export enum DateTimeFormat {
+  /** Date and time (i.e. '12/31/2024 10:29 AM') */
+  DATE_TIME = 'date_time',
+  /** Date only (i.e. '12/31/2024' or '12/31/2024' or '2024/12/31') */
+  DATE = 'date',
+  /** Time only (i.e. '10:29' or '10:29 AM') */
+  TIME = 'time',
+  /** Time with seconds (i.e. '10:29:47' or '10:29:47 AM') */
+  TIME_SECS = 'time_secs',
+}
+
+export type DefaultDateTimeFormats = {
+  [key in DateTimeFormat]: {
+    /** The function to be called on the Date object to retrieve the formatted date string */
+    toStringFn: string;
+    /** The date format options */
+    options?: Intl.DateTimeFormatOptions;
+  };
+};

--- a/packages/components/src/components/date-time/utils.ts
+++ b/packages/components/src/components/date-time/utils.ts
@@ -1,0 +1,36 @@
+import { DateTimeFormat, DefaultDateTimeFormats } from './interfaces';
+
+/**
+ * Default date format options.
+ */
+export const DEFAULT_DATE_TIME_FORMAT = DateTimeFormat.DATE_TIME;
+export const DEFAULT_DATE_TIME_FORMATS: DefaultDateTimeFormats = {
+  [DateTimeFormat.DATE_TIME]: {
+    toStringFn: 'toLocaleString',
+    options: {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  },
+  [DateTimeFormat.DATE]: {
+    toStringFn: 'toLocaleDateString',
+  },
+  [DateTimeFormat.TIME]: {
+    toStringFn: 'toLocaleTimeString',
+    options: {
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  },
+  [DateTimeFormat.TIME_SECS]: {
+    toStringFn: 'toLocaleTimeString',
+    options: {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    },
+  },
+};

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -42,6 +42,7 @@ export * from './text-ellipsis';
 export * from './time-picker';
 export * from './toast';
 export * from './validation';
+export * from './date-time';
 
 export {
   Card,

--- a/packages/components/stories/DateTime.stories.tsx
+++ b/packages/components/stories/DateTime.stories.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable react/display-name */
+import '../src/styles';
+import './stories.css';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { DateTime } from '../src/components/date-time/DateTime';
+import { DateTimeFormat } from '../src/components/date-time/interfaces';
+
+const meta: Meta<typeof DateTime> = {
+  component: DateTime,
+  title: 'Components/DateTime',
+  args: {
+    date: new Date(2024, 11, 30, 17, 30, 15).toISOString(),
+  },
+  argTypes: {
+    date: {
+      control: 'text',
+    },
+    format: {
+      control: { type: 'select' },
+      options: Object.values(DateTimeFormat),
+    },
+    locale: {
+      control: { type: 'select' },
+      options: [undefined, 'en-US', 'fr-FR', 'ja-JP'],
+    },
+    show12HourTime: {
+      control: { type: 'select' },
+      options: [undefined, true, false],
+    },
+    dateFormat: {
+      control: { type: 'select' },
+      options: [
+        undefined,
+        'MM/dd/yyyy',
+        'dd/MM/yyyy',
+        'yyyy/MM/dd',
+        'dd-MM-yyyy',
+      ],
+    },
+    timeFormat: {
+      control: { type: 'select' },
+      options: [undefined, 'hh:mm a', 'HH:mm', 'HH:mm:ss'],
+    },
+  },
+} satisfies Meta<typeof DateTime>;
+
+export default meta;
+type Story = StoryObj<typeof DateTime>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const FormatDateTime: Story = {
+  name: 'Date and Time',
+  args: {
+    format: DateTimeFormat.DATE_TIME,
+  },
+};
+
+export const FormatDateOnly: Story = {
+  name: 'Date',
+  args: {
+    format: DateTimeFormat.DATE,
+  },
+};
+
+export const FormatTime: Story = {
+  name: 'Time',
+  args: {
+    format: DateTimeFormat.TIME,
+  },
+};
+
+export const FormatTimeWithSeconds: Story = {
+  name: 'Time with Seconds',
+  args: {
+    format: DateTimeFormat.TIME_SECS,
+  },
+};
+
+export const InvalidDateInput: Story = {
+  name: 'Invalid Date String',
+  args: {
+    date: 'this-is-not-a-valid-date-string',
+    format: DateTimeFormat.DATE_TIME,
+  },
+};
+
+export const EnglishLocale: Story = {
+  name: 'English Locale',
+  args: {
+    locale: 'en-US',
+  },
+};
+
+export const FrenchLocale: Story = {
+  name: 'French Locale',
+  args: {
+    locale: 'fr-FR',
+  },
+};
+
+export const JapaneseLocale: Story = {
+  name: 'Japanese Locale',
+  args: {
+    locale: 'ja-JP',
+  },
+};


### PR DESCRIPTION
[UPL-151](https://perzoinc.atlassian.net/browse/UPL-151): `DateTime` component

New `DateTime` component allowing to display a date or a time (or both) according to the provided settings. By default, renders date and time using the browser locale formatting.

Properties:
- `date`: the date information to display (ISO string or Date)
- `format`: one of:
  - `DATE_TIME` (default): renders the date and time (i.e. '12/31/2024 10:29 AM')
  - `DATE`: renders the date (i.e. '12/31/2024')
  - `TIME`: renders the time (i.e. '10:29 AM')
  - `TIME_SECS`: renders the time with seconds (i.e. '10:29:47 AM')
- `locale`: the locale to use for date and time formatting (i.e. 'fr-FR') - default is the browser locale
- `show12HourTime`: whether to display the time in 12-hour format (i.e. '05:29 PM')
- `dateFormat`: the format to use for the date (i.e. 'yyyy/MM/dd') - overrides the locale formatting
- `timeFormat`: the format to use for the time (i.e. 'hh:mm:ss a') - overrides the locale formatting, the `show12HourTime` prop and may affect the display of time seconds

-------

https://github.com/user-attachments/assets/3472e2a8-f2b9-495f-b73f-268db39bfaae

[UPL-151]: https://perzoinc.atlassian.net/browse/UPL-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ