### PR TITLE
RTC-15509 - Not trigger onClose for DropdownMenu if event comes from a Modal

### DIFF
--- a/packages/components/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/packages/components/src/components/dropdown-menu/DropdownMenu.tsx
@@ -92,16 +92,26 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     }
   };
 
-  const keyboardEventHandler = (e: KeyboardEvent) => {
-    e.stopPropagation();
-    if(e.key === Keys.ESC) {
+  const keyboardEventHandler = (event: KeyboardEvent) => {
+    event.stopPropagation();
+    const eventFiredFromModal = event.composedPath().some((element) => {
+      return (element as Element).className === 'tk-dialog-backdrop'
+    });
+    if(event.key === Keys.ESC && !eventFiredFromModal) {
       onClose?.();
     }
   }
 
-  const mouseEventHandler = (e: MouseEvent) => {
-    e.stopPropagation();
-    if (ref.current && !e.composedPath().includes(ref.current)) {
+  const mouseEventHandler = (event: MouseEvent) => {
+    event.stopPropagation();
+    const eventFiredFromModal = event.composedPath().some((element) => {
+      return (element as Element).className === 'tk-dialog-backdrop'
+    });
+    if (
+      ref.current &&
+      !event.composedPath().includes(ref.current) &&
+      !eventFiredFromModal
+    ) {
       onClose?.();
     }
   }


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/CES-22535
https://perzoinc.atlassian.net/browse/RTC-15509

- An item in a `DropdownMenu` opens a `Modal` component. When closing that `Modal`, it would also close the `DropdownMenu`. If we check the composedPath for `tk-dialog-backdrop` we know the mouse event or keyboard event stems from the `Modal`.

Update: before merging this one I would like to know where does this requirement come from. Is this truly the expected behaviour?