### PR TITLE
C2-26167 - Default async value not initialized

### DIFF
--- a/packages/components/spec/components/dropdown/Dropdown.spec.tsx
+++ b/packages/components/spec/components/dropdown/Dropdown.spec.tsx
@@ -47,6 +47,10 @@ describe('Dropdown component test suite =>', () => {
     id: 'testId',
   };
 
+  afterEach(() => {
+    onInit.mockClear();
+  })
+
   describe('when options are Sync', () => {
     beforeEach(() => {
       dropdownProps.options = options;
@@ -608,6 +612,7 @@ describe('Dropdown component test suite =>', () => {
           expect(queryByText('orange')).toBeFalsy();
         });
       });
+
       describe('when `defaultOptions` is provided with a different list', () => {
         it('should render different default options to the dropdown menu', async () => {
           const { getByText } = render(
@@ -620,6 +625,7 @@ describe('Dropdown component test suite =>', () => {
           userEvent.click(input);
           expect(getByText('salmon')).toBeTruthy();
         });
+
         it('should filter the options if user types on the input', async () => {
           const { getByText, queryByText } = render(
             <Dropdown
@@ -721,6 +727,40 @@ describe('Dropdown component test suite =>', () => {
         userEvent.click(cross);
         expect(onClear).toBeCalled();
         expect(getByText('Select...')).toBeTruthy();
+      });
+
+      it('should call onInit function only once, when component is initialized', async () => {
+        const dropdownComponent = render(
+          <Dropdown
+            asyncOptions={() => Promise.resolve(options)}
+            onInit={onInit}
+            value={undefined}
+            isInitialized={false}
+          />
+        );
+        expect(onInit).not.toHaveBeenCalled();
+
+        dropdownComponent.rerender(
+          <Dropdown
+            asyncOptions={() => Promise.resolve(options)}
+            onInit={onInit}
+            value="value"
+            isInitialized={true}
+          />
+        );
+        expect(onInit).toHaveBeenCalledTimes(1);
+        expect(onInit).toHaveBeenCalledWith('value');
+
+        dropdownComponent.rerender(
+          <Dropdown
+            asyncOptions={() => Promise.resolve(options)}
+            onInit={onInit}
+            value="value2"
+            isInitialized={true}
+          />
+        );
+        expect(onInit).toHaveBeenCalledTimes(1);
+        expect(onInit).toHaveBeenCalledWith('value');
       });
     });
 

--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -39,6 +39,8 @@ export class Dropdown<T = LabelValue> extends React.Component<
   myRef: any;
   searchHeaderOption: any;
   lastSelectedOption: any;
+  onInitCalled: boolean = false;
+
   constructor(props) {
     super(props);
 
@@ -64,9 +66,18 @@ export class Dropdown<T = LabelValue> extends React.Component<
   }
 
   componentDidMount() {
-    const { onInit, value } = this.props;
-    if (onInit && value) {
+    const { onInit, value, isInitialized } = this.props;
+    if (!this.onInitCalled && isInitialized !== false && onInit && value) {
       onInit(value as any);
+      this.onInitCalled = true;
+    }
+  }
+
+  componentDidUpdate() {
+    const { onInit, value, isInitialized } = this.props;
+    if (!this.onInitCalled && !!isInitialized && onInit && value) {
+      onInit(value as any);
+      this.onInitCalled = true;
     }
   }
 

--- a/packages/components/src/components/dropdown/interfaces.ts
+++ b/packages/components/src/components/dropdown/interfaces.ts
@@ -123,6 +123,8 @@ export type DropdownProps<T> = {
   inputAlwaysDisplayed?: boolean;
   /** The value of the search input */
   inputValue?: string;
+  /** Used for async dropdowns, especially with initial values, should be true when 'value' field is correctly populated. */
+  isInitialized?: boolean;
   /** Is the select value clearable */
   isInputClearable?: boolean;
   /** If false, user can not type on the control Input */


### PR DESCRIPTION
## Description

Issue was affecting both PersonSelector and RoomSelector, that both have async load of initial value, with initial value and required.
The init method that initializes the value with default value in the validators was not called with the initial values, because of the async loading of the values.
Only the id is given and the values are then loaded asynchronously.
But the init method was called only on mount. At the time of mount, the value was still undefined.

Solution implemented here is to pass an isInitialized prop that is set to true when initial values are initialized correctly.
Because we could also "not have" initial value... and we still want to call the onInit in that case.

https://github.com/SymphonyOSF/NEXUS/pull/1767

## JIRA ticket

[C2-26167](https://perzoinc.atlassian.net/browse/C2-26167)

## Demo

https://github.com/user-attachments/assets/4d1857ea-ff18-417b-9841-6242bd5910d2

[C2-26167]: https://perzoinc.atlassian.net/browse/C2-26167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ