### PR TITLE
CES-22621 - Fix menuitem role for all screen reader

### DIFF
--- a/packages/components/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/packages/components/src/components/dropdown-menu/DropdownMenu.tsx
@@ -65,7 +65,7 @@ export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({
     onClick?.(event);
   }, [loading])
 
-  return <div {...rest} className={classes} role="menu-item" onClick={onClickHandler} ref={forwardRef} onKeyDown={onKeyDownHandler} tabIndex={0}>
+  return <div {...rest} className={classes} role="menuitem" onClick={onClickHandler} ref={forwardRef} onKeyDown={onKeyDownHandler} tabIndex={0}>
     {loading ? <Loader variant="primary" /> : children}
   </div>
 }


### PR DESCRIPTION
## Description

Although `menu-item` role seems to be recognized by voice over on Mac, it is not recognized on Windows with tools like NVDA. This PR aims to fix it. by using `menuitem` role instead (without hyphen)

## JIRA ticket

[CES-22621](https://perzoinc.atlassian.net/browse/CES-22621)


[CES-22621]: https://perzoinc.atlassian.net/browse/CES-22621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ